### PR TITLE
🐛 修复 windows 下生成 dll 库带 linux 前缀导致查找不到控件

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -38,6 +38,10 @@ set(RC_ICONS
     favicon.ico
 )
 
+if(WIN32)
+	set(CMAKE_SHARED_LIBRARY_PREFIX "")
+endif()
+
 qt_add_resources(QT_RESOURCES ${RESOURCES})
 
 add_executable(${PROJECT_NAME} ${SOURCES} ${HEADERS} ${QT_RESOURCES} ${RC_ICONS})


### PR DESCRIPTION
因为 cmake 在 windows 下生成 dll 时会带有 lib 的前缀，导致 qml 在 import 库时无法找到，因此通过去掉前缀来修复这个问题