### PR TITLE
🐛 修复 windows 下生成 dll 库带 linux 前缀导致查找不到控件

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,10 @@ set(QT_INSTALL_QML ${Qt6Core_DIR}/../../../qml)
 set(TARGET_TYPE SHARED)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/FluentUI)
 
+if(WIN32)
+	set(CMAKE_SHARED_LIBRARY_PREFIX "")
+endif()
+
 set(TARGET_RESOURCES res.qrc)
 set(TARGET_SOURCES
     Def.cpp


### PR DESCRIPTION
因为 cmake 在 windows 下生成 dll 时会带有 lib 的前缀，导致 qml 在 import 库时无法找到，因此通过去掉前缀来修复这个问题