### PR TITLE
Add automatic dark color mode switching function.

### DIFF
--- a/src/FluTheme.cpp
+++ b/src/FluTheme.cpp
@@ -1,6 +1,8 @@
 ﻿#include "FluTheme.h"
 
 #include "FluColors.h"
+#include <QPalette>
+#include <QGuiApplication>
 
 FluTheme* FluTheme::m_instance = nullptr;
 
@@ -19,5 +21,13 @@ FluTheme::FluTheme(QObject *parent)
     textSize(13);
     nativeText(true);
     frameless(true);
-    dark(false);
+    std::function<bool()> isDark = [](){
+        QPalette palette = (qobject_cast<QGuiApplication *>(QCoreApplication::instance()))->palette();
+        QColor color = palette.color(QPalette::Window).rgb();
+        return !(color.red() * 0.2126 + color.green() * 0.7152 + color.blue() * 0.0722 > 255 / 2);
+    };
+    dark(isDark());
+    connect(qobject_cast<QGuiApplication *>(QCoreApplication::instance()), &QGuiApplication::paletteChanged, this, [=] (const QPalette &) {
+        dark(isDark());
+    });
 }


### PR DESCRIPTION
加入跟随系统自动切换深/亮色模式的功能。
在macOS 13.4 beta 2（Mac mini M2 2023）上测试通过。
演示视频：
https://user-images.githubusercontent.com/30333935/232242526-4aa4d9f0-5e56-47d8-8de7-79c9752b3dbc.mov
演示动图：
![视频](https://user-images.githubusercontent.com/30333935/232244946-deb76ac7-f2ae-4894-a825-75f394b4acce.gif)
