### PR TITLE
Imporve FluContentDialog and add relative example.

### DIFF
--- a/example/T_Dialog.qml
+++ b/example/T_Dialog.qml
@@ -18,14 +18,14 @@ FluScrollablePage{
         height: 68
         paddings: 10
         Layout.topMargin: 20
-            FluButton{
-                anchors.verticalCenter: parent.verticalCenter
-                Layout.topMargin: 20
-                text:"Show Dialog"
-                onClicked: {
-                    dialog.open()
-                }
+        FluButton{
+            anchors.verticalCenter: parent.verticalCenter
+            Layout.topMargin: 20
+            text:"Show Double Button Dialog"
+            onClicked: {
+                double_btn_dialog.open()
             }
+        }
     }
     CodeExpander{
         Layout.fillWidth: true
@@ -35,6 +35,7 @@ FluScrollablePage{
     title:"友情提示"
     message:"确定要退出程序么？"
     negativeText:"取消"
+    buttonFlags: FluContentDialog.NegativeButton | FluContentDialog.PositiveButton
     onNegativeClicked:{
         showSuccess("点击取消按钮")
     }
@@ -42,15 +43,15 @@ FluScrollablePage{
     onPositiveClicked:{
         showSuccess("点击确定按钮")
     }
-}
-dialog.open()
-'
+    }
+    dialog.open()'
     }
 
     FluContentDialog{
-        id:dialog
+        id:double_btn_dialog
         title:"友情提示"
         message:"确定要退出程序么？"
+        buttonFlags: FluContentDialog.NegativeButton | FluContentDialog.PositiveButton
         negativeText:"取消"
         onNegativeClicked:{
             showSuccess("点击取消按钮")
@@ -61,5 +62,61 @@ dialog.open()
         }
     }
 
+    FluArea{
+        Layout.fillWidth: true
+        height: 68
+        paddings: 10
+        Layout.topMargin: 20
+        FluButton{
+            anchors.verticalCenter: parent.verticalCenter
+            Layout.topMargin: 20
+            text:"Show Triple Button Dialog"
+            onClicked: {
+                triple_btn_dialog.open()
+            }
+        }
+    }
+    CodeExpander{
+        Layout.fillWidth: true
+        Layout.topMargin: -1
+        code:'FluContentDialog{
+    id:dialog
+    title:"友情提示"
+    message:"确定要退出程序么？"
+    negativeText:"取消"
+        buttonFlags: FluContentDialog.NeutralButton | FluContentDialog.NegativeButton | FluContentDialog.PositiveButton
+        negativeText:"取消"
+        onNegativeClicked:{
+            showSuccess("点击取消按钮")
+        }
+        positiveText:"确定"
+        onPositiveClicked:{
+            showSuccess("点击确定按钮")
+        }
+        neutralText:"最小化"
+        onNeutralClicked:{
+            showSuccess("点击最小化按钮")
+        }
+    }
+    dialog.open()'
+    }
 
+    FluContentDialog{
+        id:triple_btn_dialog
+        title:"友情提示"
+        message:"确定要退出程序么？"
+        buttonFlags: FluContentDialog.NeutralButton | FluContentDialog.NegativeButton | FluContentDialog.PositiveButton
+        negativeText:"取消"
+        onNegativeClicked:{
+            showSuccess("点击取消按钮")
+        }
+        positiveText:"确定"
+        onPositiveClicked:{
+            showSuccess("点击确定按钮")
+        }
+        neutralText:"最小化"
+        onNeutralClicked:{
+            showSuccess("点击最小化按钮")
+        }
+    }
 }

--- a/example/page/MainPage.qml
+++ b/example/page/MainPage.qml
@@ -46,6 +46,32 @@ FluWindow {
             }
     }
 
+    FluContentDialog{
+        id:close_app
+        title:"退出"
+        message:"确定要退出程序吗？"
+        negativeText:"最小化"
+        buttonFlags: FluContentDialog.NeutralButton | FluContentDialog.NegativeButton | FluContentDialog.PositiveButton
+        onNegativeClicked:{
+            showSuccess("最小化成功")
+            window.hide()
+        }
+        positiveText:"退出"
+        neutralText:"取消"
+        onPositiveClicked:{
+            window.destoryWindow()
+            FluApp.closeApp()
+        }
+
+    }
+
+    onClosing:
+    {
+        window.show()
+        window.raise()
+        window.requestActivate()
+        close_app.open()
+    }
 
     FluNavigationView{
         id:nav_view

--- a/src/controls/FluContentDialog.qml
+++ b/src/controls/FluContentDialog.qml
@@ -7,11 +7,19 @@ Popup {
     id: popup
 
     property string title: "Title"
-    property string message: "Messaeg"
+    property string message: "Message"
+    property string neutralText: "Neutral"
     property string negativeText: "Negative"
     property string positiveText: "Positive"
+    signal neutralClicked
     signal negativeClicked
     signal positiveClicked
+    enum ButtonFlag{
+        NegativeButton=1
+        ,NeutralButton=2
+        ,PositiveButton=4
+    }
+    property int buttonFlags: FluContentDialog.NegativeButton | FluContentDialog.PositiveButton
     property var minWidth: {
         if(Window.window==null)
             return 400
@@ -74,40 +82,48 @@ Popup {
                 right: parent.right
             }
 
-            Item {
-                id:divider
-                width: 1
-                height: parent.height
-                anchors.centerIn: parent
-            }
+            RowLayout{
+                anchors
+                {
+                    centerIn: parent
+                    margins: spacing
+                    fill: parent
+                }
+                spacing: 15
+                FluButton{
+                    id:neutral_btn
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    visible: popup.buttonFlags&FluContentDialog.NeutralButton
+                    text: neutralText
+                    onClicked: {
+                        popup.close()
+                        neutralClicked()
+                    }
+                }
 
-            FluButton{
-                anchors{
-                    left: parent.left
-                    leftMargin: 20
-                    rightMargin: 10
-                    right: divider.left
-                    verticalCenter: parent.verticalCenter
+                FluButton{
+                    id:negative_btn
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    visible: popup.buttonFlags&FluContentDialog.NegativeButton
+                    text: negativeText
+                    onClicked: {
+                        popup.close()
+                        negativeClicked()
+                    }
                 }
-                text: negativeText
-                onClicked: {
-                    popup.close()
-                    negativeClicked()
-                }
-            }
 
-            FluFilledButton{
-                anchors{
-                    right: parent.right
-                    left: divider.right
-                    rightMargin: 20
-                    leftMargin: 10
-                    verticalCenter: parent.verticalCenter
-                }
-                text: positiveText
-                onClicked: {
-                    popup.close()
-                    positiveClicked()
+                FluFilledButton{
+                    id:positive_btn
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    visible: popup.buttonFlags&FluContentDialog.PositiveButton
+                    text: positiveText
+                    onClicked: {
+                        popup.close()
+                        positiveClicked()
+                    }
                 }
             }
         }


### PR DESCRIPTION
以枚举类型为FluContentDialog提供三个按钮（FluContentDialog.NeutralButton、FluContentDialog.NegativeButton 、FluContentDialog.PositiveButton）的选择，并提供相应代码例子，为example程序窗口加入退出询问机制。
<img width="1000" alt="image" src="https://user-images.githubusercontent.com/30333935/233336252-e965c08b-3eef-43de-8e52-9cacc41fa364.png">
