### PR TITLE
Use Qt6 compatible blur effect.

### DIFF
--- a/example/qml/page/T_Acrylic.qml
+++ b/example/qml/page/T_Acrylic.qml
@@ -20,21 +20,23 @@ FluScrollablePage{
             height: 1200/5
             radius:[15,15,15,15]
             Image {
+                id:image
                 asynchronous: true
                 source: "qrc:/example/res/image/banner_3.jpg"
                 anchors.fill: parent
                 sourceSize: Qt.size(width,height)
-                FluAcrylic {
-                    anchors.bottom: parent.bottom
-                    anchors.right: parent.right
-                    width: 100
-                    height: 100
-                    FluText {
-                        anchors.centerIn: parent
-                        text: "Acrylic"
-                        color: "#FFFFFF"
-                        font.bold: true
-                    }
+            }
+            FluAcrylic {
+                sourceItem:image
+                anchors.bottom: parent.bottom
+                anchors.right: parent.right
+                width: 100
+                height: 100
+                FluText {
+                    anchors.centerIn: parent
+                    text: "Acrylic"
+                    color: "#FFFFFF"
+                    font.bold: true
                 }
             }
             Layout.topMargin: 20
@@ -45,15 +47,17 @@ FluScrollablePage{
         Layout.fillWidth: true
         Layout.topMargin: -1
         code:'Image{
+    id:image
     width: 800
     height: 600
     source: "qrc:/example/res/image/image_huoyin.webp"
     radius: 8
+    }
     FluAcrylic{
+        sourceItem:image
         width: 100
         height: 100
         anchors.centerIn: parent
-    }
 }'
     }
 

--- a/src/imports/FluentUI/Controls/FluAcrylic.qml
+++ b/src/imports/FluentUI/Controls/FluAcrylic.qml
@@ -23,11 +23,9 @@ Item {
         sourceRect: Qt.rect(control.x, control.y, control.width, control.height)
     }
 
-    GaussianBlur {
+    FastBlur {
         radius: 20
         anchors.fill: effect_source
         source: effect_source
-        samples: 1 + radius * 2
     }
-
 }


### PR DESCRIPTION
使用兼容Qt 6的模糊效果（FastBlur，根据QT 6官方文档，高斯模糊由于不兼容新的着色器而被废弃，使用FastBlur效果不能将效果实例作为需要模糊对象的子项）。

补充：macOS下测试没有GaussianBlur这一QML type。