### PR TITLE
Add PageMode for FluNavigationView.

### DIFF
--- a/src/imports/FluentUI/Controls/FluContentPage.qml
+++ b/src/imports/FluentUI/Controls/FluContentPage.qml
@@ -12,6 +12,8 @@ Item {
     property int topPadding: 0
     property int rightPadding: 0
     property int bottomPadding: 0
+    property int pageMode: FluNavigationView.SingleTask
+    property string url: ''
 
     id:control
 

--- a/src/imports/FluentUI/Controls/FluNavigationView.qml
+++ b/src/imports/FluentUI/Controls/FluNavigationView.qml
@@ -22,6 +22,12 @@ Item {
     property Component autoSuggestBox
     property Component actionItem
 
+    enum PageModeFlag{
+        Standard = 0,
+        SingleTop = 1,
+        SingleTask = 2
+    }
+
     id:control
 
     QtObject{
@@ -900,7 +906,32 @@ Item {
     }
 
     function push(url){
-        nav_swipe.push(url)
+        if (nav_swipe.depth>0)
+        {
+            let page = nav_swipe.find(function(item) {
+                return item.url === url;
+            })
+            if (page)
+            {
+                switch(page.pageMode)
+                {
+                    case FluNavigationView.SingleTask:
+                        while(nav_swipe.currentItem !== page)
+                        {
+                            nav_swipe.pop()
+                            d.stackItems.pop()
+                        }
+                        return
+                    case FluNavigationView.SingleTop:
+                        if (nav_swipe.currentItem.url === url)
+                            return
+                        break
+                    case FluNavigationView.Standard:
+                    default:
+                }
+            }
+        }
+        nav_swipe.push(url,{url:url})
     }
 
     function getCurrentIndex(){

--- a/src/imports/FluentUI/Controls/FluScrollablePage.qml
+++ b/src/imports/FluentUI/Controls/FluScrollablePage.qml
@@ -13,6 +13,8 @@ Item {
     property int topPadding: 0
     property int rightPadding: 10
     property int bottomPadding: 10
+    property int pageMode: FluNavigationView.SingleTask
+    property string url: ''
 
     id:control
 


### PR DESCRIPTION
模仿Android的Activity四种启动模式，为FluNavigationView增加三种页面加载模式：
+ Standard：标准模式，即每次点击标签按钮，FluNavigationView都将添加该页面的新实例，即便栈内已存在该页面实例。
+ SingleTop：栈顶复用模式，如果页面已是栈顶页面（即是FluNavigationView当前显示页面），将不再添加该页面的新实例（本想再加入一个类似Android的onNewIntent提示用的信号，但想想好像用不太上，就没加了）
+ SingleTask：栈内单例模式，栈内只存在相同页面的一个实例，假设用户共依次打开编号为1-5的界面，当处于5号界面，使用FluNavigationView切换至2号界面时，3-5号界面都将出栈并被销毁。
为解决 #92 #88 两个issues提供暂时的解决方法，个人认为SwipeView会是最合适的解决方案，之后有时间再实践一下。
