### PR TITLE
解决GCC类编译器链接的问题，修正framelesshelper中的flag

### DIFF
--- a/example/src/main.cpp
+++ b/example/src/main.cpp
@@ -21,7 +21,9 @@ FRAMELESSHELPER_USE_NAMESPACE
     QGuiApplication::setOrganizationDomain("https://zhuzichu520.github.io");
     QGuiApplication::setApplicationName("FluentUI");
     QGuiApplication app(argc, argv);
+#ifdef Q_OS_WIN // 此设置仅在Windows下生效
     FramelessConfig::instance()->set(Global::Option::ForceHideWindowFrameBorder);
+#endif
     FramelessConfig::instance()->set(Global::Option::DisableLazyInitializationForMicaMaterial);
     FramelessConfig::instance()->set(Global::Option::CenterWindowBeforeShow);
     FramelessConfig::instance()->set(Global::Option::ForceNonNativeBackgroundBlur);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,4 +72,9 @@ if(WIN32)
 endif()
 
 #如果是debug，则生成的库文件名后面拼接d
-set_target_properties(fluentuiplugin PROPERTIES DEBUG_POSTFIX "d")
+# 在MinGW和GCC/Clang中, 默认不会链接带`d`后缀的动态库
+if(MSVC)
+    set_target_properties(fluentuiplugin PROPERTIES DEBUG_POSTFIX "d")  
+endif(MSVC)
+
+


### PR DESCRIPTION
参见：
 https://github.com/zhuzichu520/FluentUI/issues/127#issuecomment-1563724504

+ 多次尝试后，发现CMake中的

https://github.com/zhuzichu520/FluentUI/blob/a123dfbccf9136cede4ba085d231b54cf190646d/src/CMakeLists.txt#L74-L75

仅在MSVC上生效，在MinGW/GCC/Clang等编译器进行链接的时候，除非手动指定，否则不会链接这个生成的debug库。


+ framelesshelper中的`Global::Option::ForceHideWindowFrameBorder`选项仅在Windows上生效
