### PR TITLE
增加vs2022 msbuild文件 适配多个版本的qt  痛过修改fluentuiplugin.vcxproj以及example.vcx…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ bin
 build
 cmake-build-*
 .idea
+/generated
+/.vs/FluentUI-qt5-MSBuild


### PR DESCRIPTION
…proj中的QtDir路径 实现不同qt5版本的切换