### PR TITLE
ms-build相关文件上传

### DIFF
--- a/FluentUI-qt5-MSBuild.sln
+++ b/FluentUI-qt5-MSBuild.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.6.33723.286
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "example", "example\example.vcxproj", "{14E0AE1F-22B9-346D-BB43-DEC7FD9D7A88}"
+	ProjectSection(ProjectDependencies) = postProject
+		{8C2A72B4-E552-38E4-B572-26B6BED54CA8} = {8C2A72B4-E552-38E4-B572-26B6BED54CA8}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "fluentuiplugin", "src\fluentuiplugin.vcxproj", "{8C2A72B4-E552-38E4-B572-26B6BED54CA8}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{14E0AE1F-22B9-346D-BB43-DEC7FD9D7A88}.Debug|x64.ActiveCfg = Debug|x64
+		{14E0AE1F-22B9-346D-BB43-DEC7FD9D7A88}.Debug|x64.Build.0 = Debug|x64
+		{14E0AE1F-22B9-346D-BB43-DEC7FD9D7A88}.Release|x64.ActiveCfg = Release|x64
+		{14E0AE1F-22B9-346D-BB43-DEC7FD9D7A88}.Release|x64.Build.0 = Release|x64
+		{8C2A72B4-E552-38E4-B572-26B6BED54CA8}.Debug|x64.ActiveCfg = Debug|x64
+		{8C2A72B4-E552-38E4-B572-26B6BED54CA8}.Debug|x64.Build.0 = Debug|x64
+		{8C2A72B4-E552-38E4-B572-26B6BED54CA8}.Release|x64.ActiveCfg = Release|x64
+		{8C2A72B4-E552-38E4-B572-26B6BED54CA8}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {EDE66BDE-8C86-4165-AD2A-C13E0876CA93}
+	EndGlobalSection
+EndGlobal

--- a/example/example.vcxproj
+++ b/example/example.vcxproj
@@ -1,0 +1,449 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{14E0AE1F-22B9-346D-BB43-DEC7FD9D7A88}</ProjectGuid>
+    <RootNamespace>example</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <QtDir>C:\Qt\Qt5.14.2\5.14.2\msvc2017_64</QtDir>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <PlatformToolset>v143</PlatformToolset>
+    <ATLMinimizesCRunTimeLibraryUsage>false</ATLMinimizesCRunTimeLibraryUsage>
+    <CharacterSet>NotSet</CharacterSet>
+    <ConfigurationType>Application</ConfigurationType>
+    <PrimaryOutput>example</PrimaryOutput>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <PlatformToolset>v143</PlatformToolset>
+    <ATLMinimizesCRunTimeLibraryUsage>false</ATLMinimizesCRunTimeLibraryUsage>
+    <CharacterSet>NotSet</CharacterSet>
+    <ConfigurationType>Application</ConfigurationType>
+    <PrimaryOutput>example</PrimaryOutput>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)bin\$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\generated\$(ProjectName)\obj\release\</IntDir>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">example</TargetName>
+    <IgnoreImportLibrary Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</IgnoreImportLibrary>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</LinkIncremental>
+    <PreLinkEventUseInBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</PreLinkEventUseInBuild>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)bin\$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\generated\$(ProjectName)\obj\debug\</IntDir>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">example</TargetName>
+    <IgnoreImportLibrary Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</IgnoreImportLibrary>
+    <PreLinkEventUseInBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</PreLinkEventUseInBuild>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(QtDir)\include;C:\Qt\Qt5.14.2\5.14.2\msvc2017_64\include\QtQuick;$(QtDir)\include\QtGui;$(QtDir)\include\QtANGLE;$(QtDir)\include\QtQmlModels;$(QtDir)\include\QtQml;$(QtDir)\include\QtNetwork;$(QtDir)\include\QtConcurrent;$(QtDir)\include\QtCore;release;/include;$(QtDir)\mkspecs\win32-msvc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/permissive- -Zc:rvalueCast -Zc:inline -Zc:strictStrings -Zc:throwingNew -Zc:referenceBinding -Zc:__cplusplus -w34100 -w34189 -w44996 -w44456 -w44457 -w44458 %(AdditionalOptions)</AdditionalOptions>
+      <AssemblerListingLocation>$(SolutionDir)\generated\$(ProjectName)\obj\release\</AssemblerListingLocation>
+      <BrowseInformation>false</BrowseInformation>
+      <DebugInformationFormat>None</DebugInformationFormat>
+      <DisableSpecificWarnings>4577;4467;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <ObjectFileName>$(SolutionDir)\generated\$(ProjectName)\obj\release\</ObjectFileName>
+      <Optimization>MaxSpeed</Optimization>
+      <PreprocessorDefinitions>_WINDOWS;UNICODE;_UNICODE;WIN32;_ENABLE_EXTENDED_ALIGNED_STORAGE;WIN64;QT_DEPRECATED_WARNINGS;QT_NO_WARNING_OUTPUT;QUICK_USE_QMAKE;VERSION=1,3,1,0;NDEBUG;QT_NO_DEBUG;QT_QUICK_LIB;QT_GUI_LIB;QT_QMLMODELS_LIB;QT_QML_LIB;QT_NETWORK_LIB;QT_CONCURRENT_LIB;QT_CORE_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessToFile>false</PreprocessToFile>
+      <ProgramDataBaseFileName>
+      </ProgramDataBaseFileName>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
+      <WarningLevel>Level3</WarningLevel>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>$(QtDir)\lib\Qt5Quick.lib;$(QtDir)\lib\Qt5Gui.lib;$(QtDir)\lib\Qt5QmlModels.lib;$(QtDir)\lib\Qt5Qml.lib;$(QtDir)\lib\Qt5Network.lib;$(QtDir)\lib\Qt5Concurrent.lib;$(QtDir)\lib\Qt5Core.lib;$(QtDir)\lib\qtmain.lib;shell32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>C:\openssl\lib;C:\Utils\my_sql\mysql-5.7.25-winx64\lib;C:\Utils\postgresql\pgsql\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalOptions>"/MANIFESTDEPENDENCY:type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' publicKeyToken='6595b64144ccf1df' language='*' processorArchitecture='*'" %(AdditionalOptions)</AdditionalOptions>
+      <DataExecutionPrevention>true</DataExecutionPrevention>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <IgnoreImportLibrary>true</IgnoreImportLibrary>
+      <LinkIncremental>false</LinkIncremental>
+      <OptimizeReferences>true</OptimizeReferences>
+      <OutputFile>$(OutDir)\example.exe</OutputFile>
+      <RandomizedBaseAddress>true</RandomizedBaseAddress>
+      <SubSystem>Windows</SubSystem>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+    </Link>
+    <Midl>
+      <DefaultCharType>Unsigned</DefaultCharType>
+      <EnableErrorChecks>None</EnableErrorChecks>
+      <WarningLevel>0</WarningLevel>
+    </Midl>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_WINDOWS;UNICODE;_UNICODE;WIN32;_ENABLE_EXTENDED_ALIGNED_STORAGE;WIN64;QT_DEPRECATED_WARNINGS;QT_NO_WARNING_OUTPUT;QUICK_USE_QMAKE;VERSION=1,3,1,0;NDEBUG;QT_NO_DEBUG;QT_QUICK_LIB;QT_GUI_LIB;QT_QMLMODELS_LIB;QT_QML_LIB;QT_NETWORK_LIB;QT_CONCURRENT_LIB;QT_CORE_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+    <PreLinkEvent>
+      <Command>copy /y C:\Users\lyxm1\source\repos\TEST_PROGRAM\TEST_QML\FluentUI-qt5-MSBuild\3rdparty\msvc\*.dll C:\Users\lyxm1\source\repos\TEST_PROGRAM\TEST_QML\FluentUI-qt5-MSBuild\bin\release</Command>
+      <Message>copy /y C:\Users\lyxm1\source\repos\TEST_PROGRAM\TEST_QML\FluentUI-qt5-MSBuild\3rdparty\msvc\*.dll C:\Users\lyxm1\source\repos\TEST_PROGRAM\TEST_QML\FluentUI-qt5-MSBuild\bin\release</Message>
+    </PreLinkEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(QtDir)\include;$(QtDir)\include\QtQuick;$(QtDir)\include\QtGui;C$(QtDir)\include\QtANGLE;$(QtDir)\include\QtQmlModels;$(QtDir)\include\QtQml;$(QtDir)\include\QtNetwork;$(QtDir)\include\QtConcurrent;$(QtDir)\include\QtCore;debug;/include;$(QtDir)\mkspecs\win32-msvc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/permissive- -Zc:rvalueCast -Zc:inline -Zc:strictStrings -Zc:throwingNew -Zc:referenceBinding -Zc:__cplusplus -w34100 -w34189 -w44996 -w44456 -w44457 -w44458 %(AdditionalOptions)</AdditionalOptions>
+      <AssemblerListingLocation>$(SolutionDir)\generated\$(ProjectName)\obj\debug\</AssemblerListingLocation>
+      <BrowseInformation>false</BrowseInformation>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <DisableSpecificWarnings>4577;4467;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <ObjectFileName>$(SolutionDir)\generated\$(ProjectName)\obj\debug\</ObjectFileName>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_WINDOWS;UNICODE;_UNICODE;WIN32;_ENABLE_EXTENDED_ALIGNED_STORAGE;WIN64;QT_DEPRECATED_WARNINGS;QT_NO_WARNING_OUTPUT;QUICK_USE_QMAKE;VERSION=1,3,1,0;QT_QUICK_LIB;QT_GUI_LIB;QT_QMLMODELS_LIB;QT_QML_LIB;QT_NETWORK_LIB;QT_CONCURRENT_LIB;QT_CORE_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessToFile>false</PreprocessToFile>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
+      <WarningLevel>Level3</WarningLevel>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>$(QtDir)\lib\Qt5Quickd.lib;$(QtDir)\lib\Qt5Guid.lib;$(QtDir)\lib\Qt5QmlModelsd.lib;$(QtDir)\lib\Qt5Qmld.lib;$(QtDir)\lib\Qt5Networkd.lib;$(QtDir)\lib\Qt5Concurrentd.lib;$(QtDir)\lib\Qt5Cored.lib;$(QtDir)\lib\qtmaind.lib;shell32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>C:\openssl\lib;C:\Utils\my_sql\mysql-5.7.25-winx64\lib;C:\Utils\postgresql\pgsql\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalOptions>"/MANIFESTDEPENDENCY:type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' publicKeyToken='6595b64144ccf1df' language='*' processorArchitecture='*'" %(AdditionalOptions)</AdditionalOptions>
+      <DataExecutionPrevention>true</DataExecutionPrevention>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <IgnoreImportLibrary>true</IgnoreImportLibrary>
+      <OutputFile>$(OutDir)\example.exe</OutputFile>
+      <RandomizedBaseAddress>true</RandomizedBaseAddress>
+      <SubSystem>Windows</SubSystem>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+    </Link>
+    <Midl>
+      <DefaultCharType>Unsigned</DefaultCharType>
+      <EnableErrorChecks>None</EnableErrorChecks>
+      <WarningLevel>0</WarningLevel>
+    </Midl>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_WINDOWS;UNICODE;_UNICODE;WIN32;_ENABLE_EXTENDED_ALIGNED_STORAGE;WIN64;QT_DEPRECATED_WARNINGS;QT_NO_WARNING_OUTPUT;QUICK_USE_QMAKE;VERSION=1,3,1,0;QT_QUICK_LIB;QT_GUI_LIB;QT_QMLMODELS_LIB;QT_QML_LIB;QT_NETWORK_LIB;QT_CONCURRENT_LIB;QT_CORE_LIB;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+    <PreLinkEvent>
+      <Command>copy /y $(SolutionDir)\3rdparty\msvc\*.dll $(OutDir)</Command>
+      <Message>copy /y $(SolutionDir)\3rdparty\msvc\*.dll $(OutDir)</Message>
+    </PreLinkEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="src\AppInfo.cpp" />
+    <ClCompile Include="src\lang\En.cpp" />
+    <ClCompile Include="src\tool\IPC.cpp" />
+    <ClCompile Include="src\lang\Lang.cpp" />
+    <ClCompile Include="src\lang\Zh.cpp" />
+    <ClCompile Include="src\main.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="src\AppInfo.h">
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_predefs.h;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(QtDir)\bin\moc %(FullPath) -o $(SolutionDir)\generated\$(ProjectName)\moc\release\moc_%(Filename).cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MOC %(Filename).h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_%(Filename).cpp;%(Outputs)</Outputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_predefs.h;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QtDir)\bin\moc %(FullPath) -o $(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_%(Filename).cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">MOC %(Filename).h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_%(Filename).cpp;%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="src\lang\En.h">
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_predefs.h;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(QtDir)\bin\moc %(FullPath) -o $(SolutionDir)\generated\$(ProjectName)\moc\release\moc_%(Filename).cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MOC %(Filename).h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_%(Filename).cpp;%(Outputs)</Outputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_predefs.h;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QtDir)\bin\moc %(FullPath) -o $(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_%(Filename).cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">MOC %(Filename).h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_%(Filename).cpp;%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="src\tool\IPC.h">
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_predefs.h;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(QtDir)\bin\moc %(FullPath) -o $(SolutionDir)\generated\$(ProjectName)\moc\release\moc_%(Filename).cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MOC %(Filename).h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_%(Filename).cpp;%(Outputs)</Outputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_predefs.h;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QtDir)\bin\moc %(FullPath) -o $(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_%(Filename).cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">MOC %(Filename).h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_%(Filename).cpp;%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="src\lang\Lang.h">
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_predefs.h;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(QtDir)\bin\moc %(FullPath) -o $(SolutionDir)\generated\$(ProjectName)\moc\release\moc_%(Filename).cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MOC %(Filename).h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_%(Filename).cpp;%(Outputs)</Outputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_predefs.h;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QtDir)\bin\moc %(FullPath) -o $(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_%(Filename).cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">MOC %(Filename).h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_%(Filename).cpp;%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="src\lang\Zh.h">
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_predefs.h;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(QtDir)\bin\moc %(FullPath) -o $(SolutionDir)\generated\$(ProjectName)\moc\release\moc_%(Filename).cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MOC %(Filename).h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_%(Filename).cpp;%(Outputs)</Outputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_predefs.h;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QtDir)\bin\moc %(FullPath) -o $(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_%(Filename).cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">MOC %(Filename).h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_%(Filename).cpp;%(Outputs)</Outputs>
+    </CustomBuild>
+    <ClInclude Include="src\stdafx.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_AppInfo.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_AppInfo.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_En.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_En.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_IPC.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_IPC.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_Lang.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_Lang.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_Zh.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_Zh.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <CustomBuild Include="moc_debug_predefs.h.cbt">
+      <FileType>Document</FileType>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QtDir)\mkspecs\features\data\dummy.cpp;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">cl -Bx$(QtDir)\bin\qmake.exe -E $(QtDir)\mkspecs\features\data\dummy.cpp 2&gt;NUL &gt;$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_predefs.h</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Generate moc_predefs.h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_predefs.h;%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="moc_release_predefs.h.cbt">
+      <FileType>Document</FileType>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(QtDir)\mkspecs\features\data\dummy.cpp;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">cl -Bx$(QtDir)\bin\qmake.exe -E $(QtDir)\mkspecs\features\data\dummy.cpp 2&gt;NUL &gt;$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_predefs.h</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Generate moc_predefs.h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_predefs.h;%(Outputs)</Outputs>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+    </CustomBuild>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\debug\qrc_example.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\release\qrc_example.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="qml\window\AboutWindow.qml" />
+    <None Include="res\image\control\Acrylic.png" />
+    <None Include="res\image\control\AnimatedIcon.png" />
+    <None Include="res\image\control\AnimatedVisualPlayer.png" />
+    <None Include="res\image\control\AnimationInterop.png" />
+    <None Include="qml\App.qml" />
+    <None Include="res\image\control\AppBarButton.png" />
+    <None Include="res\image\control\AppBarSeparator.png" />
+    <None Include="res\image\control\AppBarToggleButton.png" />
+    <None Include="res\image\control\AutoSuggestBox.png" />
+    <None Include="res\image\control\AutomationProperties.png" />
+    <None Include="res\image\control\Border.png" />
+    <None Include="res\image\control\BreadcrumbBar.png" />
+    <None Include="res\image\control\Button.png" />
+    <None Include="res\image\control\CalendarDatePicker.png" />
+    <None Include="res\image\control\CalendarView.png" />
+    <None Include="res\image\control\Canvas.png" />
+    <None Include="res\image\control\Checkbox.png" />
+    <None Include="res\image\control\Clipboard.png" />
+    <None Include="qml\component\CodeExpander.qml" />
+    <None Include="res\image\control\ColorPaletteResources.png" />
+    <None Include="res\image\control\ColorPicker.png" />
+    <None Include="res\image\control\ComboBox.png" />
+    <None Include="res\image\control\CommandBar.png" />
+    <None Include="res\image\control\CommandBarFlyout.png" />
+    <None Include="res\image\control\CompactSizing.png" />
+    <None Include="res\image\control\ConnectedAnimation.png" />
+    <None Include="res\image\control\ContentDialog.png" />
+    <None Include="res\image\control\CreateMultipleWindows.png" />
+    <None Include="res\image\control\DataGrid.png" />
+    <None Include="res\image\control\DatePicker.png" />
+    <None Include="res\image\control\DropDownButton.png" />
+    <None Include="res\image\control\EasingFunction.png" />
+    <None Include="res\image\control\Expander.png" />
+    <None Include="res\image\control\FilePicker.png" />
+    <None Include="res\image\control\FlipView.png" />
+    <None Include="res\image\control\Flyout.png" />
+    <None Include="res\image\control\Grid.png" />
+    <None Include="res\image\control\GridView.png" />
+    <None Include="res\image\control\HyperlinkButton.png" />
+    <None Include="res\image\control\IconElement.png" />
+    <None Include="res\image\control\Image.png" />
+    <None Include="res\image\control\ImplicitTransition.png" />
+    <None Include="res\image\control\InfoBadge.png" />
+    <None Include="res\image\control\InfoBar.png" />
+    <None Include="res\image\control\InkCanvas.png" />
+    <None Include="res\image\control\InkToolbar.png" />
+    <None Include="res\image\control\InputValidation.png" />
+    <None Include="qml\global\ItemsFooter.qml" />
+    <None Include="qml\global\ItemsOriginal.qml" />
+    <None Include="res\image\control\ItemsRepeater.png" />
+    <None Include="res\image\control\Line.png" />
+    <None Include="res\image\control\ListBox.png" />
+    <None Include="res\image\control\ListView.png" />
+    <None Include="qml\window\LoginWindow.qml" />
+    <None Include="qml\global\MainEvent.qml" />
+    <None Include="qml\window\MainWindow.qml" />
+    <None Include="res\image\control\MediaPlayerElement.png" />
+    <None Include="res\image\control\MenuBar.png" />
+    <None Include="res\image\control\MenuFlyout.png" />
+    <None Include="res\image\control\NavigationView.png" />
+    <None Include="res\image\control\NumberBox.png" />
+    <None Include="res\image\control\PageTransition.png" />
+    <None Include="res\image\control\ParallaxView.png" />
+    <None Include="res\image\control\PasswordBox.png" />
+    <None Include="res\image\control\PersonPicture.png" />
+    <None Include="res\image\control\PipsPager.png" />
+    <None Include="res\image\control\Pivot.png" />
+    <None Include="res\image\control\ProgressBar.png" />
+    <None Include="res\image\control\ProgressRing.png" />
+    <None Include="res\image\control\PullToRefresh.png" />
+    <None Include="res\image\control\RadialGradientBrush.png" />
+    <None Include="res\image\control\RadioButton.png" />
+    <None Include="res\image\control\RadioButtons.png" />
+    <None Include="res\image\control\RatingControl.png" />
+    <None Include="res\image\control\RelativePanel.png" />
+    <None Include="res\image\control\RepeatButton.png" />
+    <None Include="res\image\control\RevealFocus.png" />
+    <None Include="res\image\control\RichEditBox.png" />
+    <None Include="res\image\control\RichTextBlock.png" />
+    <None Include="res\image\control\ScrollViewer.png" />
+    <None Include="res\image\control\SemanticZoom.png" />
+    <None Include="res\image\control\Shape.png" />
+    <None Include="qml\window\SingleInstanceWindow.qml" />
+    <None Include="qml\window\SingleTaskWindow.qml" />
+    <None Include="res\image\control\Slider.png" />
+    <None Include="res\image\control\Sound.png" />
+    <None Include="res\image\control\SplitButton.png" />
+    <None Include="res\image\control\SplitView.png" />
+    <None Include="res\image\control\StackPanel.png" />
+    <None Include="res\image\control\StandardUICommand.png" />
+    <None Include="qml\window\StandardWindow.qml" />
+    <None Include="res\image\control\SwipeControl.png" />
+    <None Include="qml\page\T_Acrylic.qml" />
+    <None Include="qml\page\T_Awesome.qml" />
+    <None Include="qml\page\T_Badge.qml" />
+    <None Include="qml\page\T_BreadcrumbBar.qml" />
+    <None Include="qml\page\T_Buttons.qml" />
+    <None Include="qml\page\T_CalendarPicker.qml" />
+    <None Include="qml\page\T_Carousel.qml" />
+    <None Include="qml\page\T_CheckBox.qml" />
+    <None Include="qml\page\T_ColorPicker.qml" />
+    <None Include="qml\page\T_ComboBox.qml" />
+    <None Include="qml\page\T_DatePicker.qml" />
+    <None Include="qml\page\T_Dialog.qml" />
+    <None Include="qml\page\T_Expander.qml" />
+    <None Include="qml\page\T_FlipView.qml" />
+    <None Include="qml\page\T_Home.qml" />
+    <None Include="qml\page\T_InfoBar.qml" />
+    <None Include="qml\page\T_Menu.qml" />
+    <None Include="qml\page\T_MultiWindow.qml" />
+    <None Include="qml\page\T_Pivot.qml" />
+    <None Include="qml\page\T_Progress.qml" />
+    <None Include="qml\page\T_RatingControl.qml" />
+    <None Include="qml\page\T_Rectangle.qml" />
+    <None Include="qml\page\T_Settings.qml" />
+    <None Include="qml\page\T_Slider.qml" />
+    <None Include="qml\page\T_StatusView.qml" />
+    <None Include="qml\page\T_TabView.qml" />
+    <None Include="qml\page\T_TableView.qml" />
+    <None Include="qml\page\T_Text.qml" />
+    <None Include="qml\page\T_TextBox.qml" />
+    <None Include="qml\page\T_Theme.qml" />
+    <None Include="qml\page\T_TimePicker.qml" />
+    <None Include="qml\page\T_ToggleSwitch.qml" />
+    <None Include="qml\page\T_Tooltip.qml" />
+    <None Include="qml\page\T_TreeView.qml" />
+    <None Include="qml\page\T_Typography.qml" />
+    <None Include="res\image\control\TabView.png" />
+    <None Include="res\image\control\TeachingTip.png" />
+    <None Include="qml\TestWindow.qml" />
+    <None Include="res\image\control\TextBlock.png" />
+    <None Include="res\image\control\TextBox.png" />
+    <None Include="res\image\control\ThemeTransition.png" />
+    <None Include="res\image\control\TimePicker.png" />
+    <None Include="res\image\control\TitleBar.png" />
+    <None Include="res\image\control\ToggleButton.png" />
+    <None Include="res\image\control\ToggleSplitButton.png" />
+    <None Include="res\image\control\ToggleSwitch.png" />
+    <None Include="res\image\control\ToolTip.png" />
+    <None Include="res\image\control\TreeView.png" />
+    <None Include="res\image\control\VariableSizedWrapGrid.png" />
+    <None Include="res\image\control\Viewbox.png" />
+    <None Include="res\image\control\WebView.png" />
+    <None Include="res\image\control\XamlUICommand.png" />
+    <None Include="res\svg\avatar_1.svg" />
+    <None Include="res\svg\avatar_10.svg" />
+    <None Include="res\svg\avatar_11.svg" />
+    <None Include="res\svg\avatar_12.svg" />
+    <None Include="res\svg\avatar_2.svg" />
+    <None Include="res\svg\avatar_3.svg" />
+    <None Include="res\svg\avatar_4.svg" />
+    <None Include="res\svg\avatar_5.svg" />
+    <None Include="res\svg\avatar_6.svg" />
+    <None Include="res\svg\avatar_7.svg" />
+    <None Include="res\svg\avatar_8.svg" />
+    <None Include="res\svg\avatar_9.svg" />
+    <None Include="res\image\banner_1.jpg" />
+    <None Include="res\image\banner_2.jpg" />
+    <None Include="res\image\banner_3.jpg" />
+    <None Include="res\image\bg_home_header.png" />
+    <CustomBuild Include="example.qrc">
+      <FileType>Document</FileType>
+      <FileType>Document</FileType>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(QtDir)\bin\rcc %(FullPath) -o $(SolutionDir)\generated\$(ProjectName)\moc\release\qrc_%(Filename).cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">RCC %(Filename).qrc</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\release\qrc_%(Filename).cpp;%(Outputs)</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QtDir)\bin\rcc %(FullPath) -o $(SolutionDir)\generated\$(ProjectName)\moc\debug\qrc_%(Filename).cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">RCC %(Filename).qrc</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\debug\qrc_%(Filename).cpp;%(Outputs)</Outputs>
+    </CustomBuild>
+    <None Include="res\image\favicon.ico" />
+    <None Include="res\svg\home.svg" />
+    <None Include="res\svg\home_dark.svg" />
+    <None Include="res\image\ic_home_github.png" />
+    <None Include="res\image\logo_openai.png" />
+    <None Include="qml\global\qmldir" />
+    <None Include="res\image\qrcode_wx.jpg" />
+    <None Include="res\image\qrcode_zfb.jpg" />
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="example.rc" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/example/example.vcxproj.filters
+++ b/example/example.vcxproj.filters
@@ -1,0 +1,638 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Generated Files">
+      <UniqueIdentifier>{71ED8ED8-ACB9-4CE9-BBE1-E00B30144E11}</UniqueIdentifier>
+      <Extensions>cpp;c;cxx;moc;h;def;odl;idl;res;</Extensions>
+    </Filter>
+    <Filter Include="Generated Files">
+      <UniqueIdentifier>{71ED8ED8-ACB9-4CE9-BBE1-E00B30144E11}</UniqueIdentifier>
+      <Extensions>cpp;c;cxx;moc;h;def;odl;idl;res;</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{D9D6E242-F8AF-46E4-B9FD-80ECBC20BA3E}</UniqueIdentifier>
+      <Extensions>qrc;*</Extensions>
+      <ParseFiles>false</ParseFiles>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{D9D6E242-F8AF-46E4-B9FD-80ECBC20BA3E}</UniqueIdentifier>
+      <Extensions>qrc;*</Extensions>
+      <ParseFiles>false</ParseFiles>
+    </Filter>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="src\AppInfo.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\lang\En.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\tool\IPC.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\lang\Lang.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\lang\Zh.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\main.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="src\AppInfo.h">
+      <Filter>Header Files</Filter>
+    </CustomBuild>
+    <CustomBuild Include="src\lang\En.h">
+      <Filter>Header Files</Filter>
+    </CustomBuild>
+    <CustomBuild Include="src\tool\IPC.h">
+      <Filter>Header Files</Filter>
+    </CustomBuild>
+    <CustomBuild Include="src\lang\Lang.h">
+      <Filter>Header Files</Filter>
+    </CustomBuild>
+    <CustomBuild Include="src\lang\Zh.h">
+      <Filter>Header Files</Filter>
+    </CustomBuild>
+    <ClInclude Include="src\stdafx.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_AppInfo.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_AppInfo.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_En.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_En.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_IPC.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_IPC.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_Lang.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_Lang.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_Zh.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_Zh.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+    <CustomBuild Include="moc_debug_predefs.h.cbt">
+      <Filter>Generated Files</Filter>
+    </CustomBuild>
+    <CustomBuild Include="moc_release_predefs.h.cbt">
+      <Filter>Generated Files</Filter>
+    </CustomBuild>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\debug\qrc_example.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\release\qrc_example.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="qml\window\AboutWindow.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\Acrylic.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\AnimatedIcon.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\AnimatedVisualPlayer.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\AnimationInterop.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\App.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\AppBarButton.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\AppBarSeparator.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\AppBarToggleButton.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\AutoSuggestBox.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\AutomationProperties.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\Border.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\BreadcrumbBar.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\Button.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\CalendarDatePicker.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\CalendarView.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\Canvas.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\Checkbox.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\Clipboard.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\component\CodeExpander.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\ColorPaletteResources.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\ColorPicker.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\ComboBox.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\CommandBar.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\CommandBarFlyout.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\CompactSizing.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\ConnectedAnimation.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\ContentDialog.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\CreateMultipleWindows.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\DataGrid.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\DatePicker.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\DropDownButton.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\EasingFunction.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\Expander.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\FilePicker.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\FlipView.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\Flyout.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\Grid.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\GridView.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\HyperlinkButton.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\IconElement.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\Image.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\ImplicitTransition.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\InfoBadge.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\InfoBar.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\InkCanvas.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\InkToolbar.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\InputValidation.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\global\ItemsFooter.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\global\ItemsOriginal.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\ItemsRepeater.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\Line.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\ListBox.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\ListView.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\window\LoginWindow.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\global\MainEvent.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\window\MainWindow.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\MediaPlayerElement.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\MenuBar.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\MenuFlyout.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\NavigationView.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\NumberBox.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\PageTransition.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\ParallaxView.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\PasswordBox.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\PersonPicture.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\PipsPager.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\Pivot.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\ProgressBar.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\ProgressRing.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\PullToRefresh.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\RadialGradientBrush.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\RadioButton.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\RadioButtons.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\RatingControl.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\RelativePanel.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\RepeatButton.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\RevealFocus.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\RichEditBox.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\RichTextBlock.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\ScrollViewer.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\SemanticZoom.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\Shape.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\window\SingleInstanceWindow.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\window\SingleTaskWindow.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\Slider.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\Sound.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\SplitButton.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\SplitView.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\StackPanel.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\StandardUICommand.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\window\StandardWindow.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\SwipeControl.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\page\T_Acrylic.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\page\T_Awesome.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\page\T_Badge.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\page\T_BreadcrumbBar.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\page\T_Buttons.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\page\T_CalendarPicker.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\page\T_Carousel.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\page\T_CheckBox.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\page\T_ColorPicker.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\page\T_ComboBox.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\page\T_DatePicker.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\page\T_Dialog.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\page\T_Expander.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\page\T_FlipView.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\page\T_Home.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\page\T_InfoBar.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\page\T_Menu.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\page\T_MultiWindow.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\page\T_Pivot.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\page\T_Progress.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\page\T_RatingControl.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\page\T_Rectangle.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\page\T_Settings.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\page\T_Slider.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\page\T_StatusView.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\page\T_TabView.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\page\T_TableView.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\page\T_Text.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\page\T_TextBox.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\page\T_Theme.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\page\T_TimePicker.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\page\T_ToggleSwitch.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\page\T_Tooltip.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\page\T_TreeView.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\page\T_Typography.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\TabView.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\TeachingTip.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\TestWindow.qml">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\TextBlock.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\TextBox.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\ThemeTransition.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\TimePicker.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\TitleBar.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\ToggleButton.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\ToggleSplitButton.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\ToggleSwitch.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\ToolTip.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\TreeView.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\VariableSizedWrapGrid.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\Viewbox.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\WebView.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\control\XamlUICommand.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\svg\avatar_1.svg">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\svg\avatar_10.svg">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\svg\avatar_11.svg">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\svg\avatar_12.svg">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\svg\avatar_2.svg">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\svg\avatar_3.svg">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\svg\avatar_4.svg">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\svg\avatar_5.svg">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\svg\avatar_6.svg">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\svg\avatar_7.svg">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\svg\avatar_8.svg">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\svg\avatar_9.svg">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\banner_1.jpg">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\banner_2.jpg">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\banner_3.jpg">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\bg_home_header.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <CustomBuild Include="example.qrc">
+      <Filter>Resource Files</Filter>
+    </CustomBuild>
+    <None Include="res\image\favicon.ico">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\svg\home.svg">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\svg\home_dark.svg">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\ic_home_github.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\logo_openai.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="qml\global\qmldir">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\qrcode_wx.jpg">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="res\image\qrcode_zfb.jpg">
+      <Filter>Resource Files</Filter>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="example.rc" />
+  </ItemGroup>
+</Project>

--- a/example/example.vcxproj.user
+++ b/example/example.vcxproj.user
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup />
+</Project>

--- a/example/moc_debug_predefs.h.cbt
+++ b/example/moc_debug_predefs.h.cbt
@@ -1,0 +1,10 @@
+#define _MSC_EXTENSIONS 
+#define _MSC_VER 1936
+#define _MSC_FULL_VER 193632532
+#define _MSC_BUILD 0
+#define _M_AMD64 100
+#define _M_X64 100
+#define _WIN64 
+#define _WIN32 
+#define _CPPRTTI 
+#define _MT 

--- a/example/moc_release_predefs.h.cbt
+++ b/example/moc_release_predefs.h.cbt
@@ -1,0 +1,1 @@
+This is a dummy file needed to create release/moc_predefs.h

--- a/src/fluentuiplugin.vcxproj
+++ b/src/fluentuiplugin.vcxproj
@@ -1,0 +1,342 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{8C2A72B4-E552-38E4-B572-26B6BED54CA8}</ProjectGuid>
+    <RootNamespace>fluentuiplugin</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <QtDir>C:\Qt\Qt5.14.2\5.14.2\msvc2017_64</QtDir>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <PlatformToolset>v143</PlatformToolset>
+    <ATLMinimizesCRunTimeLibraryUsage>false</ATLMinimizesCRunTimeLibraryUsage>
+    <CharacterSet>NotSet</CharacterSet>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PrimaryOutput>fluentuiplugin</PrimaryOutput>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <PlatformToolset>v143</PlatformToolset>
+    <ATLMinimizesCRunTimeLibraryUsage>false</ATLMinimizesCRunTimeLibraryUsage>
+    <CharacterSet>NotSet</CharacterSet>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PrimaryOutput>fluentuiplugind</PrimaryOutput>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(QtDir)\qml\FluentUI\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\generated\$(ProjectName)\obj\release\</IntDir>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">fluentuiplugin</TargetName>
+    <IgnoreImportLibrary Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</IgnoreImportLibrary>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</LinkIncremental>
+    <PreLinkEventUseInBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</PreLinkEventUseInBuild>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QtDir)\qml\FluentUI\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\generated\$(ProjectName)\obj\debug\</IntDir>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">fluentuiplugind</TargetName>
+    <IgnoreImportLibrary Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</IgnoreImportLibrary>
+    <PreLinkEventUseInBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</PreLinkEventUseInBuild>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(QtDir)\include;$(QtDir)\include\QtQuick;$(QtDir)\include\QtGui;$(QtDir)\include\QtANGLE;$(QtDir)\include\QtQmlModels;$(QtDir)\include\QtQml;$(QtDir)\include\QtNetwork;$(QtDir)\include\QtCore;debug;/include;$(QtDir)\mkspecs\win32-msvc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/permissive- -Zc:rvalueCast -Zc:inline -Zc:strictStrings -Zc:throwingNew -Zc:referenceBinding -Zc:__cplusplus -w34100 -w34189 -w44996 -w44456 -w44457 -w44458 %(AdditionalOptions)</AdditionalOptions>
+      <AssemblerListingLocation>$(SolutionDir)\generated\$(ProjectName)\obj\release\</AssemblerListingLocation>
+      <BrowseInformation>false</BrowseInformation>
+      <DebugInformationFormat>None</DebugInformationFormat>
+      <DisableSpecificWarnings>4577;4467;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <ObjectFileName>$(SolutionDir)\generated\$(ProjectName)\obj\release\</ObjectFileName>
+      <Optimization>MaxSpeed</Optimization>
+      <PreprocessorDefinitions>_WINDOWS;UNICODE;_UNICODE;WIN32;_ENABLE_EXTENDED_ALIGNED_STORAGE;WIN64;VERSION=1,3,1,0;NDEBUG;QT_NO_DEBUG;QT_PLUGIN;QT_QUICK_LIB;QT_GUI_LIB;QT_QMLMODELS_LIB;QT_QML_LIB;QT_NETWORK_LIB;QT_CORE_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessToFile>false</PreprocessToFile>
+      <ProgramDataBaseFileName>
+      </ProgramDataBaseFileName>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
+      <WarningLevel>Level3</WarningLevel>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>$(QtDir)\lib\Qt5Quick.lib;$(QtDir)\lib\Qt5Gui.lib;$(QtDir)\lib\Qt5QmlModels.lib;$(QtDir)\lib\Qt5Qml.lib;$(QtDir)\lib\Qt5Network.lib;$(QtDir)\lib\Qt5Core.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <DataExecutionPrevention>true</DataExecutionPrevention>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <IgnoreImportLibrary>true</IgnoreImportLibrary>
+      <LinkDLL>true</LinkDLL>
+      <LinkIncremental>false</LinkIncremental>
+      <OptimizeReferences>true</OptimizeReferences>
+      <OutputFile>$(OutDir)\fluentuiplugin.dll</OutputFile>
+      <RandomizedBaseAddress>true</RandomizedBaseAddress>
+      <SubSystem>Windows</SubSystem>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+    </Link>
+    <Midl>
+      <DefaultCharType>Unsigned</DefaultCharType>
+      <EnableErrorChecks>None</EnableErrorChecks>
+      <WarningLevel>0</WarningLevel>
+    </Midl>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_WINDOWS;UNICODE;_UNICODE;WIN32;_ENABLE_EXTENDED_ALIGNED_STORAGE;WIN64;VERSION=1,3,1,0;NDEBUG;QT_NO_DEBUG;QT_PLUGIN;QT_QUICK_LIB;QT_GUI_LIB;QT_QMLMODELS_LIB;QT_QML_LIB;QT_NETWORK_LIB;QT_CORE_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+    <PreLinkEvent>
+      <Command>xcopy /s /q /y /i $(ProjectDir)\imports\FluentUI\** $(QtDir)\qml\FluentUI</Command>
+      <Message>xcopy /s /q /y /i $(ProjectDir)\imports\FluentUI\** $(QtDir)\qml\FluentUI</Message>
+    </PreLinkEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(QtDir)\include;$(QtDir)\include\QtQuick;$(QtDir)\include\QtGui;$(QtDir)\include\QtANGLE;$(QtDir)\include\QtQmlModels;$(QtDir)\include\QtQml;$(QtDir)\include\QtNetwork;$(QtDir)\include\QtCore;debug;/include;$(QtDir)\mkspecs\win32-msvc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/permissive- -Zc:rvalueCast -Zc:inline -Zc:strictStrings -Zc:throwingNew -Zc:referenceBinding -Zc:__cplusplus -w34100 -w34189 -w44996 -w44456 -w44457 -w44458 %(AdditionalOptions)</AdditionalOptions>
+      <AssemblerListingLocation>$(SolutionDir)\generated\$(ProjectName)\obj\debug\</AssemblerListingLocation>
+      <BrowseInformation>false</BrowseInformation>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <DisableSpecificWarnings>4577;4467;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <ObjectFileName>$(SolutionDir)\generated\$(ProjectName)\obj\debug\</ObjectFileName>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_WINDOWS;UNICODE;_UNICODE;WIN32;_ENABLE_EXTENDED_ALIGNED_STORAGE;WIN64;VERSION=1,3,1,0;QT_PLUGIN;QT_QUICK_LIB;QT_GUI_LIB;QT_QMLMODELS_LIB;QT_QML_LIB;QT_NETWORK_LIB;QT_CORE_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessToFile>false</PreprocessToFile>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
+      <WarningLevel>Level3</WarningLevel>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>$(QtDir)\lib\Qt5Quickd.lib;$(QtDir)\lib\Qt5Guid.lib;$(QtDir)\lib\Qt5QmlModelsd.lib;$(QtDir)\lib\Qt5Qmld.lib;$(QtDir)\lib\Qt5Networkd.lib;$(QtDir)\lib\Qt5Cored.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <DataExecutionPrevention>true</DataExecutionPrevention>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <IgnoreImportLibrary>true</IgnoreImportLibrary>
+      <LinkDLL>true</LinkDLL>
+      <OutputFile>$(OutDir)\fluentuiplugind.dll</OutputFile>
+      <RandomizedBaseAddress>true</RandomizedBaseAddress>
+      <SubSystem>Windows</SubSystem>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+    </Link>
+    <Midl>
+      <DefaultCharType>Unsigned</DefaultCharType>
+      <EnableErrorChecks>None</EnableErrorChecks>
+      <WarningLevel>0</WarningLevel>
+    </Midl>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_WINDOWS;UNICODE;_UNICODE;WIN32;_ENABLE_EXTENDED_ALIGNED_STORAGE;WIN64;VERSION=1,3,1,0;QT_PLUGIN;QT_QUICK_LIB;QT_GUI_LIB;QT_QMLMODELS_LIB;QT_QML_LIB;QT_NETWORK_LIB;QT_CORE_LIB;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+    <PreLinkEvent>
+      <Command>xcopy /s /q /y /i $(ProjectDir)\imports\FluentUI\** $(QtDir)\qml\FluentUI</Command>
+      <Message>xcopy /s /q /y /i $(ProjectDir)\imports\FluentUI\** $(QtDir)\qml\FluentUI</Message>
+    </PreLinkEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="Def.cpp" />
+    <ClCompile Include="FluApp.cpp" />
+    <ClCompile Include="FluColorSet.cpp" />
+    <ClCompile Include="FluColors.cpp" />
+    <ClCompile Include="FluRegister.cpp" />
+    <ClCompile Include="FluTextStyle.cpp" />
+    <ClCompile Include="FluTheme.cpp" />
+    <ClCompile Include="FluTools.cpp" />
+    <ClCompile Include="WindowHelper.cpp" />
+    <ClCompile Include="fluentuiplugin.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="Def.h">
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(QtDir)\bin\moc %(FullPath) -o $(SolutionDir)\generated\$(ProjectName)\moc\release\moc_%(Filename).cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MOC %(Filename).h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_%(Filename).cpp;%(Outputs)</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QtDir)\bin\moc %(FullPath) -o $(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_%(Filename).cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">MOC %(Filename).h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_%(Filename).cpp;%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="FluApp.h">
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_predefs.h;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(QtDir)\bin\moc %(FullPath) -o $(SolutionDir)\generated\$(ProjectName)\moc\release\moc_%(Filename).cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MOC %(Filename).h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_%(Filename).cpp;%(Outputs)</Outputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_predefs.h;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QtDir)\bin\moc %(FullPath) -o $(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_%(Filename).cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">MOC %(Filename).h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_%(Filename).cpp;%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="FluColorSet.h">
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_predefs.h;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(QtDir)\bin\moc %(FullPath) -o $(SolutionDir)\generated\$(ProjectName)\moc\release\moc_%(Filename).cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MOC %(Filename).h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_%(Filename).cpp;%(Outputs)</Outputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_predefs.h;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QtDir)\bin\moc %(FullPath) -o $(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_%(Filename).cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">MOC %(Filename).h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_%(Filename).cpp;%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="FluColors.h">
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_predefs.h;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(QtDir)\bin\moc %(FullPath) -o $(SolutionDir)\generated\$(ProjectName)\moc\release\moc_%(Filename).cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MOC %(Filename).h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_%(Filename).cpp;%(Outputs)</Outputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_predefs.h;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QtDir)\bin\moc %(FullPath) -o $(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_%(Filename).cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">MOC %(Filename).h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_%(Filename).cpp;%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="FluRegister.h">
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_predefs.h;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(QtDir)\bin\moc %(FullPath) -o $(SolutionDir)\generated\$(ProjectName)\moc\release\moc_%(Filename).cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MOC %(Filename).h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_%(Filename).cpp;%(Outputs)</Outputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_predefs.h;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QtDir)\bin\moc %(FullPath) -o $(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_%(Filename).cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">MOC %(Filename).h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_%(Filename).cpp;%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="FluTextStyle.h">
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_predefs.h;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(QtDir)\bin\moc %(FullPath) -o $(SolutionDir)\generated\$(ProjectName)\moc\release\moc_%(Filename).cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MOC %(Filename).h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_%(Filename).cpp;%(Outputs)</Outputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_predefs.h;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QtDir)\bin\moc %(FullPath) -o $(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_%(Filename).cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">MOC %(Filename).h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_%(Filename).cpp;%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="FluTheme.h">
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_predefs.h;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(QtDir)\bin\moc %(FullPath) -o $(SolutionDir)\generated\$(ProjectName)\moc\release\moc_%(Filename).cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MOC %(Filename).h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_%(Filename).cpp;%(Outputs)</Outputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_predefs.h;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QtDir)\bin\moc %(FullPath) -o $(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_%(Filename).cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">MOC %(Filename).h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_%(Filename).cpp;%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="FluTools.h">
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_predefs.h;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(QtDir)\bin\moc %(FullPath) -o $(SolutionDir)\generated\$(ProjectName)\moc\release\moc_%(Filename).cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MOC %(Filename).h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_%(Filename).cpp;%(Outputs)</Outputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_predefs.h;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QtDir)\bin\moc %(FullPath) -o $(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_%(Filename).cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">MOC %(Filename).h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_%(Filename).cpp;%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="WindowHelper.h">
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_predefs.h;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(QtDir)\bin\moc %(FullPath) -o $(SolutionDir)\generated\$(ProjectName)\moc\release\moc_%(Filename).cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MOC %(Filename).h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_%(Filename).cpp;%(Outputs)</Outputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_predefs.h;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QtDir)\bin\moc %(FullPath) -o $(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_%(Filename).cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">MOC %(Filename).h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_%(Filename).cpp;%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="fluentuiplugin.h">
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_predefs.h;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(QtDir)\bin\moc -I$(QtDir)/include -I$(QtDir)/include/QtQml %(FullPath) -o $(SolutionDir)\generated\$(ProjectName)\moc\release\moc_%(Filename).cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MOC %(Filename).h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_%(Filename).cpp;%(Outputs)</Outputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_predefs.h;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QtDir)\bin\moc -I$(QtDir)/include -I$(QtDir)/include/QtQml %(FullPath) -o $(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_%(Filename).cpp</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">MOC %(Filename).h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_%(Filename).cpp;%(Outputs)</Outputs>
+    </CustomBuild>
+    <ClInclude Include="stdafx.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_Def.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_Def.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_FluApp.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_FluApp.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_FluColorSet.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_FluColorSet.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_FluColors.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_FluColors.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_FluRegister.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_FluRegister.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_FluTextStyle.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_FluTextStyle.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_FluTheme.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_FluTheme.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_FluTools.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_FluTools.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_WindowHelper.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_WindowHelper.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_fluentuiplugin.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_fluentuiplugin.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <CustomBuild Include="moc_debug_predefs.h.cbt">
+      <FileType>Document</FileType>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QtDir)\mkspecs\features\data\dummy.cpp;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">cl -Bx$(QtDir)\bin\qmake.exe -E $(QtDir)\mkspecs\features\data\dummy.cpp 2&gt;NUL &gt;$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_predefs.h</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Generate moc_predefs.h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_predefs.h;%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Include="moc_release_predefs.h.cbt">
+      <FileType>Document</FileType>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(QtDir)\mkspecs\features\data\dummy.cpp;%(AdditionalInputs)</AdditionalInputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">cl -Bx$(QtDir)\bin\qmake.exe -E $(QtDir)\mkspecs\features\data\dummy.cpp 2&gt;NUL &gt;$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_predefs.h</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Generate moc_predefs.h</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_predefs.h;%(Outputs)</Outputs>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+    </CustomBuild>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="fluentui.rc" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/src/fluentuiplugin.vcxproj.filters
+++ b/src/fluentuiplugin.vcxproj.filters
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Generated Files">
+      <UniqueIdentifier>{71ED8ED8-ACB9-4CE9-BBE1-E00B30144E11}</UniqueIdentifier>
+      <Extensions>cpp;c;cxx;moc;h;def;odl;idl;res;</Extensions>
+    </Filter>
+    <Filter Include="Generated Files">
+      <UniqueIdentifier>{71ED8ED8-ACB9-4CE9-BBE1-E00B30144E11}</UniqueIdentifier>
+      <Extensions>cpp;c;cxx;moc;h;def;odl;idl;res;</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Def.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="FluApp.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="FluColorSet.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="FluColors.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="FluRegister.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="FluTextStyle.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="FluTheme.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="FluTools.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="WindowHelper.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="fluentuiplugin.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="Def.h">
+      <Filter>Header Files</Filter>
+    </CustomBuild>
+    <CustomBuild Include="FluApp.h">
+      <Filter>Header Files</Filter>
+    </CustomBuild>
+    <CustomBuild Include="FluColorSet.h">
+      <Filter>Header Files</Filter>
+    </CustomBuild>
+    <CustomBuild Include="FluColors.h">
+      <Filter>Header Files</Filter>
+    </CustomBuild>
+    <CustomBuild Include="FluRegister.h">
+      <Filter>Header Files</Filter>
+    </CustomBuild>
+    <CustomBuild Include="FluTextStyle.h">
+      <Filter>Header Files</Filter>
+    </CustomBuild>
+    <CustomBuild Include="FluTheme.h">
+      <Filter>Header Files</Filter>
+    </CustomBuild>
+    <CustomBuild Include="FluTools.h">
+      <Filter>Header Files</Filter>
+    </CustomBuild>
+    <CustomBuild Include="WindowHelper.h">
+      <Filter>Header Files</Filter>
+    </CustomBuild>
+    <CustomBuild Include="fluentuiplugin.h">
+      <Filter>Header Files</Filter>
+    </CustomBuild>
+    <ClInclude Include="stdafx.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_Def.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_Def.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_FluApp.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_FluApp.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_FluColorSet.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_FluColorSet.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_FluColors.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_FluColors.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_FluRegister.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_FluRegister.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_FluTextStyle.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_FluTextStyle.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_FluTheme.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_FluTheme.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_FluTools.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_FluTools.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_WindowHelper.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_WindowHelper.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\debug\moc_fluentuiplugin.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SolutionDir)\generated\$(ProjectName)\moc\release\moc_fluentuiplugin.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
+    <CustomBuild Include="moc_debug_predefs.h.cbt">
+      <Filter>Generated Files</Filter>
+    </CustomBuild>
+    <CustomBuild Include="moc_release_predefs.h.cbt">
+      <Filter>Generated Files</Filter>
+    </CustomBuild>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="fluentui.rc" />
+  </ItemGroup>
+</Project>

--- a/src/fluentuiplugin.vcxproj.user
+++ b/src/fluentuiplugin.vcxproj.user
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup />
+</Project>

--- a/src/moc_debug_predefs.h.cbt
+++ b/src/moc_debug_predefs.h.cbt
@@ -1,0 +1,10 @@
+#define _MSC_EXTENSIONS 
+#define _MSC_VER 1936
+#define _MSC_FULL_VER 193632532
+#define _MSC_BUILD 0
+#define _M_AMD64 100
+#define _M_X64 100
+#define _WIN64 
+#define _WIN32 
+#define _CPPRTTI 
+#define _MT 

--- a/src/moc_release_predefs.h.cbt
+++ b/src/moc_release_predefs.h.cbt
@@ -1,0 +1,1 @@
+This is a dummy file needed to create release/moc_predefs.h


### PR DESCRIPTION
1.根目录添加2022的sln文件 src和example文件夹分别添加vcproj文件。
2.添加的vcproj文件最开头均有一个名为<QtDir>的项，同过设置该项改变编译使用的qt5版本，输入的路径为qt的bin lib include等文件夹所在的根目录 例如C:\Qt\Qt5.14.2\5.14.2\msvc2017_64 或者
C:\Qt\Qt5.14.2\5.14.2\msvc2017_64或者C:\Qt\Qt5.15.2\5.15.2\msvc2019_64 上述版本测试均能编译通过且正常运行
3.将子工程的c++标准都升级成了17
4.程序编译后自动生成的中间文件以及Qt的Moc文件全在根目录下的generated文件夹中(该文件夹git ignored了)
5.vcproj文件中手打了各个文件的qt moc和rcc操作，因此不需要qt addin便可编译运行。
6.vcproj文件中的路径全都使用vs macro书写能够自适应正确的路径
7.没有结合FlamelessWindow相关代码
8.尝试把该工程中的QtDir设置为Qt6 发现能正常编译 但程序无法启动 会崩溃 (当前上传版本不支持Qt6编译，需要对引用lib中的Qt5和Qt6名字差异做版本区分 由于无法正常运行编译结果 所以没有上传)