### PR TITLE
examlple: Make the items in searchbox more readable.

### DIFF
--- a/example/qml/global/ItemsOriginal.qml
+++ b/example/qml/global/ItemsOriginal.qml
@@ -385,7 +385,12 @@ FluObject{
         for(var i=0;i<items.length;i++){
             var item = items[i]
             if(item instanceof FluPaneItem){
-                arr.push({title:item.title,key:item.key})
+                if (item.parent instanceof FluPaneItemExpander)
+                {
+                    arr.push({title:`${item.parent.title} -> ${item.title}`,key:item.key})
+                }
+                else
+                    arr.push({title:item.title,key:item.key})
             }
         }
         return arr


### PR DESCRIPTION
如下图所示，加入提示符号以提醒用户，避免出现无法区分不同Expander下同名项的问题（示例程序中不存在重名，若有用户直接照搬示例程序，可能出现类似情况）。
<img width="1000" alt="image" src="https://github.com/zhuzichu520/FluentUI/assets/30333935/64363ec3-9689-47ab-97ee-73d83b9a4da3">
