### PR TITLE
调整亚克力效果的噪点占比

### DIFF
--- a/src/Qt5/imports/FluentUI/Controls/FluAcrylic.qml
+++ b/src/Qt5/imports/FluentUI/Controls/FluAcrylic.qml
@@ -4,13 +4,14 @@ import FluentUI 1.0
 
 Item {
     id: control
-    property color tintColor: Qt.rgba(1,1,1,1)
+    property color tintColor: Qt.rgba(1, 1, 1, 1)
     property real tintOpacity: 0.65
     property real luminosity: 0.01
-    property real noiseOpacity : 0.066
-    property alias target : effect_source.sourceItem
+    property real noiseOpacity: 0.02
+    property alias target: effect_source.sourceItem
     property int blurRadius: 32
-    property rect targetRect : Qt.rect(control.x, control.y, control.width, control.height)
+    property rect targetRect: Qt.rect(control.x, control.y, control.width,
+                                      control.height)
     ShaderEffectSource {
         id: effect_source
         anchors.fill: parent
@@ -18,20 +19,20 @@ Item {
         sourceRect: control.targetRect
     }
     FastBlur {
-        id:fast_blur
+        id: fast_blur
         anchors.fill: parent
         source: effect_source
         radius: control.blurRadius
     }
-    Rectangle{
+    Rectangle {
         anchors.fill: parent
         color: Qt.rgba(1, 1, 1, luminosity)
     }
-    Rectangle{
+    Rectangle {
         anchors.fill: parent
         color: Qt.rgba(tintColor.r, tintColor.g, tintColor.b, tintOpacity)
     }
-    Image{
+    Image {
         anchors.fill: parent
         source: "../Image/noise.png"
         fillMode: Image.Tile

--- a/src/Qt6/imports/FluentUI/Controls/FluAcrylic.qml
+++ b/src/Qt6/imports/FluentUI/Controls/FluAcrylic.qml
@@ -4,13 +4,14 @@ import FluentUI
 
 Item {
     id: control
-    property color tintColor: Qt.rgba(1,1,1,1)
+    property color tintColor: Qt.rgba(1, 1, 1, 1)
     property real tintOpacity: 0.65
     property real luminosity: 0.01
-    property real noiseOpacity : 0.066
-    property alias target : effect_source.sourceItem
+    property real noiseOpacity: 0.02
+    property alias target: effect_source.sourceItem
     property int blurRadius: 32
-    property rect targetRect : Qt.rect(control.x, control.y, control.width, control.height)
+    property rect targetRect: Qt.rect(control.x, control.y, control.width,
+                                      control.height)
     ShaderEffectSource {
         id: effect_source
         anchors.fill: parent
@@ -18,20 +19,20 @@ Item {
         sourceRect: control.targetRect
     }
     FastBlur {
-        id:fast_blur
+        id: fast_blur
         anchors.fill: parent
         source: effect_source
         radius: control.blurRadius
     }
-    Rectangle{
+    Rectangle {
         anchors.fill: parent
         color: Qt.rgba(1, 1, 1, luminosity)
     }
-    Rectangle{
+    Rectangle {
         anchors.fill: parent
         color: Qt.rgba(tintColor.r, tintColor.g, tintColor.b, tintOpacity)
     }
-    Image{
+    Image {
         anchors.fill: parent
         source: "../Image/noise.png"
         fillMode: Image.Tile


### PR DESCRIPTION
参考官方figma winui3设计稿，噪点图像占比为2%，不然看起来噪点太明显