### PR TITLE
Use more elegant singleton and fix spell bug.

### DIFF
--- a/example/src/AppInfo.h
+++ b/example/src/AppInfo.h
@@ -13,7 +13,7 @@ class AppInfo : public QObject
 private:
     explicit AppInfo(QObject *parent = nullptr);
 public:
-    SINGLETONG(AppInfo)
+    SINGLETON(AppInfo)
 };
 
 #endif // APPINFO_H

--- a/example/src/helper/SettingsHelper.h
+++ b/example/src/helper/SettingsHelper.h
@@ -16,7 +16,7 @@ class SettingsHelper : public QObject
 private:
     explicit SettingsHelper(QObject* parent = nullptr);
 public:
-    SINGLETONG(SettingsHelper)
+    SINGLETON(SettingsHelper)
     ~SettingsHelper() override;
     void init(char *argv[]);
     Q_INVOKABLE void saveDarkMode(int darkModel){save("darkMode",darkModel);}

--- a/example/src/singleton.h
+++ b/example/src/singleton.h
@@ -34,7 +34,7 @@ T* Singleton<T>::getInstance() {
     return instance;
 }
 
-#define SINGLETONG(Class)                              \
+#define SINGLETON(Class)                              \
 private:                                               \
     friend class Singleton<Class>;              \
     friend struct QScopedPointerDeleter<Class>;        \

--- a/src/FluApp.h
+++ b/src/FluApp.h
@@ -29,7 +29,7 @@ private:
     explicit FluApp(QObject *parent = nullptr);
     ~FluApp();
 public:
-    SINGLETONG(FluApp)
+    SINGLETON(FluApp)
     static FluApp *create(QQmlEngine *qmlEngine, QJSEngine *jsEngine){return getInstance();}
     Q_INVOKABLE void run();
     Q_INVOKABLE void navigate(const QString& route,const QJsonObject& argument  = {},FluRegister* fluRegister = nullptr);

--- a/src/FluColors.h
+++ b/src/FluColors.h
@@ -51,7 +51,7 @@ class FluColors : public QObject
 private:
     explicit FluColors(QObject *parent = nullptr);
 public:
-    SINGLETONG(FluColors)
+    SINGLETON(FluColors)
     static FluColors *create(QQmlEngine *qmlEngine, QJSEngine *jsEngine){return getInstance();}
 };
 

--- a/src/FluEventBus.h
+++ b/src/FluEventBus.h
@@ -23,7 +23,7 @@ class FluEventBus : public QObject
 private:
     explicit FluEventBus(QObject *parent = nullptr);
 public:
-    SINGLETONG(FluEventBus)
+    SINGLETON(FluEventBus)
     static FluEventBus *create(QQmlEngine *qmlEngine, QJSEngine *jsEngine){return getInstance();}
     Q_INVOKABLE void registerEvent(FluEvent* event);
     Q_INVOKABLE void unRegisterEvent(FluEvent* event);

--- a/src/FluNetwork.h
+++ b/src/FluNetwork.h
@@ -104,7 +104,7 @@ class FluNetwork : public QObject
 private:
     explicit FluNetwork(QObject *parent = nullptr);
 public:
-    SINGLETONG(FluNetwork)
+    SINGLETON(FluNetwork)
     static FluNetwork *create(QQmlEngine *qmlEngine, QJSEngine *jsEngine){return getInstance();}
     Q_INVOKABLE NetworkParams* get(const QString& url);
     Q_INVOKABLE NetworkParams* head(const QString& url);

--- a/src/FluTextStyle.h
+++ b/src/FluTextStyle.h
@@ -23,7 +23,7 @@ public:
 private:
     explicit FluTextStyle(QObject *parent = nullptr);
 public:
-    SINGLETONG(FluTextStyle)
+    SINGLETON(FluTextStyle)
     static FluTextStyle *create(QQmlEngine *qmlEngine, QJSEngine *jsEngine){return getInstance();}
 };
 

--- a/src/FluTheme.h
+++ b/src/FluTheme.h
@@ -40,7 +40,7 @@ private:
     bool systemDark();
     void refreshColors();
 public:
-    SINGLETONG(FluTheme)
+    SINGLETON(FluTheme)
     Q_INVOKABLE QJsonArray awesomeList(const QString& keyword = "");
     Q_SIGNAL void darkChanged();
     static FluTheme *create(QQmlEngine *qmlEngine, QJSEngine *jsEngine){return getInstance();}

--- a/src/FluTools.h
+++ b/src/FluTools.h
@@ -19,7 +19,7 @@ class FluTools : public QObject
 private:
     explicit FluTools(QObject *parent = nullptr);
 public:
-    SINGLETONG(FluTools)
+    SINGLETON(FluTools)
     static FluTools *create(QQmlEngine *qmlEngine, QJSEngine *jsEngine){return getInstance();}
     Q_INVOKABLE int qtMajor();
     Q_INVOKABLE int qtMinor();

--- a/src/FluViewModel.h
+++ b/src/FluViewModel.h
@@ -53,7 +53,7 @@ class ViewModelManager:public QObject{
 private:
     explicit ViewModelManager(QObject *parent = nullptr);
 public:
-    SINGLETONG(ViewModelManager)
+    SINGLETON(ViewModelManager)
     bool exist(const QString& key);
     void insert(const QString& key,QObject* value);
     QObject* getModel(const QString& key);

--- a/src/FluentUI.h
+++ b/src/FluentUI.h
@@ -9,7 +9,7 @@ class FluentUI : public QObject
 {
     Q_OBJECT
 public:
-    SINGLETONG(FluentUI)
+    SINGLETON(FluentUI)
     Q_DECL_EXPORT void registerTypes(QQmlEngine *engine);
     void registerTypes(const char *uri);
     void initializeEngine(QQmlEngine *engine, const char *uri);

--- a/src/singleton.h
+++ b/src/singleton.h
@@ -2,42 +2,30 @@
 #define SINGLETON_H
 
 #include <QMutex>
-#include <QScopedPointer>
-#include <memory>
-#include <mutex>
 
 template <typename T>
 class Singleton {
 public:
     static T* getInstance();
 
-    Singleton(const Singleton& other) = delete;
-    Singleton<T>& operator=(const Singleton& other) = delete;
-
 private:
-    static std::mutex mutex;
-    static T* instance;
+    Q_DISABLE_COPY_MOVE(Singleton)
 };
 
 template <typename T>
-std::mutex Singleton<T>::mutex;
-template <typename T>
-T* Singleton<T>::instance;
-template <typename T>
 T* Singleton<T>::getInstance() {
+    static QMutex mutex;
+    QMutexLocker locker(&mutex);
+    static T* instance = nullptr;
     if (instance == nullptr) {
-        std::lock_guard<std::mutex> locker(mutex);
-        if (instance == nullptr) {
-            instance = new T();
-        }
+        instance = new T();
     }
     return instance;
 }
 
-#define SINGLETONG(Class)                              \
+#define SINGLETON(Class)                              \
 private:                                               \
     friend class Singleton<Class>;              \
-    friend struct QScopedPointerDeleter<Class>;        \
                                                        \
     public:                                                \
     static Class* getInstance() {                      \
@@ -48,6 +36,6 @@ private:                                               \
 private:                                \
     Class() = default;                  \
     Class(const Class& other) = delete; \
-    Class& operator=(const Class& other) = delete;
+    Q_DISABLE_COPY_MOVE(Class);
 
 #endif // SINGLETON_H


### PR DESCRIPTION
1.`SINGLETONG`宏定义应该是一个错误拼写，更正为`SINGLETON`
2.几个单例模式需要去除的函数Qt自带宏定义，可以简写为Q_DISABLE_COPY_MOVE
3.用Qt自带的线程锁代替标准库锁，以提高与Qt库的兼容性