### PR TITLE
fix(FluSplitLayout): solve binding loop on qt 6.6.0

### DIFF
--- a/src/Qt6/imports/FluentUI/Controls/FluSplitLayout.qml
+++ b/src/Qt6/imports/FluentUI/Controls/FluSplitLayout.qml
@@ -10,8 +10,8 @@ SplitView {
         property bool isVertical: control.orientation === Qt.Vertical
     }
     handle: Rectangle {
-        implicitWidth: 12
-        implicitHeight: 12
+        implicitWidth: d.isVertical ? control.width : 12
+        implicitHeight: d.isVertical ? 12 : control.height
         clip: true
         color: {
             if(SplitHandle.pressed){


### PR DESCRIPTION
FluSplitLayout handle's outside Rectangle use an implicitWidth/Height smaller than inside Rectangle.

this pr fix warning on qt 6.6.0:
QML Rectangle: Binding loop detected for property "height"