### PR TITLE
vs2019下example退出之后程序会崩溃

### DIFF
--- a/example/src/helper/Log.cpp
+++ b/example/src/helper/Log.cpp
@@ -207,3 +207,8 @@ void Log::setup(const QString &app,int level)
     qInfo()<<"[LOG_PATH]"<<g_file_path;
     qInfo()<<"===================================================";
 }
+
+void Log::teardown()
+{
+    qInstallMessageHandler(0);
+}

--- a/example/src/helper/Log.h
+++ b/example/src/helper/Log.h
@@ -6,6 +6,7 @@ namespace Log
 {
     QString prettyProductInfoWrapper();
     void setup(const QString &app,int level = 4);
+    void teardown();
 }
 
 #endif // LOG_H

--- a/example/src/main.cpp
+++ b/example/src/main.cpp
@@ -82,5 +82,6 @@ int main(int argc, char *argv[])
     if (exec == 931) {
         QProcess::startDetached(qApp->applicationFilePath(), QStringList());
     }
+    Log::teardown();
     return exec;
 }


### PR DESCRIPTION
在vs2019下运行example,点击关闭在main函数退出之后会在函数messageHandler内部崩溃，所以添加Log::teardown函数，在main 函数调用，对应在main函数执行的Log::setup(...)