### PR TITLE
修复日历选择器夜间模式看不到星期的问题

### DIFF
--- a/src/Qt5/imports/FluentUI/Controls/FluCalendarPicker.qml
+++ b/src/Qt5/imports/FluentUI/Controls/FluCalendarPicker.qml
@@ -449,6 +449,7 @@ FluButton {
                                 delegate: Label {
                                     text: model.shortName
                                     font: dayOfWeekRow.font
+                                    color: FluTheme.fontPrimaryColor
                                     horizontalAlignment: Text.AlignHCenter
                                     verticalAlignment: Text.AlignVCenter
                                 }

--- a/src/Qt6/imports/FluentUI/Controls/FluCalendarPicker.qml
+++ b/src/Qt6/imports/FluentUI/Controls/FluCalendarPicker.qml
@@ -448,6 +448,7 @@ FluButton {
                                 delegate: Label {
                                     text: model.shortName
                                     font: dayOfWeekRow.font
+                                    color: FluTheme.fontPrimaryColor
                                     horizontalAlignment: Text.AlignHCenter
                                     verticalAlignment: Text.AlignVCenter
                                 }


### PR DESCRIPTION
![image](https://github.com/zhuzichu520/FluentUI/assets/60976594/b31e322c-6e15-40ce-8505-1ac851b4fd04)
