### PR TITLE
修复icon按钮，单选按钮等控件disable后，控件文本仍然高亮问题

### DIFF
--- a/example/example_en_US.ts
+++ b/example/example_en_US.ts
@@ -902,7 +902,7 @@ Updated content:
         <location filename="qml/page/T_Buttons.qml" line="199"/>
         <location filename="qml/page/T_Buttons.qml" line="320"/>
         <location filename="qml/page/T_Buttons.qml" line="368"/>
-        <location filename="qml/page/T_Buttons.qml" line="421"/>
+        <location filename="qml/page/T_Buttons.qml" line="422"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1017,17 +1017,17 @@ Updated content:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qml/page/T_Buttons.qml" line="404"/>
+        <location filename="qml/page/T_Buttons.qml" line="405"/>
         <source>Radio Button_1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qml/page/T_Buttons.qml" line="408"/>
+        <location filename="qml/page/T_Buttons.qml" line="409"/>
         <source>Radio Button_2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qml/page/T_Buttons.qml" line="412"/>
+        <location filename="qml/page/T_Buttons.qml" line="413"/>
         <source>Radio Button_3</source>
         <translation type="unfinished"></translation>
     </message>

--- a/example/example_zh_CN.ts
+++ b/example/example_zh_CN.ts
@@ -929,7 +929,7 @@ Updated content:
         <location filename="qml/page/T_Buttons.qml" line="199"/>
         <location filename="qml/page/T_Buttons.qml" line="320"/>
         <location filename="qml/page/T_Buttons.qml" line="368"/>
-        <location filename="qml/page/T_Buttons.qml" line="421"/>
+        <location filename="qml/page/T_Buttons.qml" line="422"/>
         <source>Disabled</source>
         <translation type="unfinished">禁用</translation>
     </message>
@@ -1044,17 +1044,17 @@ Updated content:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qml/page/T_Buttons.qml" line="404"/>
+        <location filename="qml/page/T_Buttons.qml" line="405"/>
         <source>Radio Button_1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qml/page/T_Buttons.qml" line="408"/>
+        <location filename="qml/page/T_Buttons.qml" line="409"/>
         <source>Radio Button_2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qml/page/T_Buttons.qml" line="412"/>
+        <location filename="qml/page/T_Buttons.qml" line="413"/>
         <source>Radio Button_3</source>
         <translation type="unfinished"></translation>
     </message>

--- a/example/qml/page/T_Buttons.qml
+++ b/example/qml/page/T_Buttons.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.15
+﻿import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Window 2.15
 import QtQuick.Controls 2.15
@@ -265,7 +265,7 @@ FluScrollablePage{
             }
             FluIconButton{
                 disabled: icon_button_switch.checked
-                iconDelegate: Image{ sourceSize: Qt.size(40,40) ; width: 20; height: 20; source: "qrc:/example/res/image/ic_home_github.png" }
+                iconDelegate: FluImage{ sourceSize: Qt.size(40,40) ; width: 20; height: 20; source: "qrc:/example/res/image/ic_home_github.png" }
                 onClicked:{
                     showSuccess(qsTr("Click IconButton"))
                 }
@@ -395,6 +395,7 @@ FluScrollablePage{
         Layout.topMargin: 20
         FluRadioButtons{
             spacing: 8
+            disabled: radio_button_switch.checked
             anchors{
                 verticalCenter: parent.verticalCenter
                 left: parent.left

--- a/src/Qt5/imports/FluentUI/Controls/FluButton.qml
+++ b/src/Qt5/imports/FluentUI/Controls/FluButton.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.15
+﻿import QtQuick 2.15
 import QtQuick.Controls 2.15
 import FluentUI 1.0
 
@@ -11,17 +11,11 @@ Button {
     property color dividerColor: FluTheme.dark ? Qt.rgba(80/255,80/255,80/255,1) : Qt.rgba(233/255,233/255,233/255,1)
     property color textColor: {
         if(FluTheme.dark){
-            if(!enabled){
-                return Qt.rgba(131/255,131/255,131/255,1)
-            }
             if(pressed){
                 return Qt.rgba(162/255,162/255,162/255,1)
             }
             return Qt.rgba(1,1,1,1)
         }else{
-            if(!enabled){
-                return Qt.rgba(160/255,160/255,160/255,1)
-            }
             if(pressed){
                 return Qt.rgba(96/255,96/255,96/255,1)
             }
@@ -59,6 +53,6 @@ Button {
         horizontalAlignment: Text.AlignHCenter
         verticalAlignment: Text.AlignVCenter
         font: control.font
-        color: control.textColor
+        textColor: control.textColor
     }
 }

--- a/src/Qt5/imports/FluentUI/Controls/FluIcon.qml
+++ b/src/Qt5/imports/FluentUI/Controls/FluIcon.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.15
+﻿import QtQuick 2.15
 import QtQuick.Controls 2.15
 import FluentUI 1.0
 
@@ -11,7 +11,8 @@ Text {
     font.pixelSize: iconSize
     horizontalAlignment: Text.AlignHCenter
     verticalAlignment: Text.AlignVCenter
-    color: iconColor
+    color: enabled ? iconColor :  Qt.rgba(iconColor.r, iconColor.g, iconColor.b, iconColor.a * 0.5)
+
     text: (String.fromCharCode(iconSource).toString(16))
     opacity: iconSource>0
     FontLoader{

--- a/src/Qt5/imports/FluentUI/Controls/FluIconButton.qml
+++ b/src/Qt5/imports/FluentUI/Controls/FluIconButton.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.15
+﻿import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 import FluentUI 1.0
@@ -26,14 +26,8 @@ Button {
     }
     property color iconColor: {
         if(FluTheme.dark){
-            if(!enabled){
-                return Qt.rgba(130/255,130/255,130/255,1)
-            }
             return Qt.rgba(1,1,1,1)
         }else{
-            if(!enabled){
-                return Qt.rgba(161/255,161/255,161/255,1)
-            }
             return Qt.rgba(0,0,0,1)
         }
     }
@@ -82,7 +76,7 @@ Button {
                 text:control.text
                 Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
                 visible: display !== Button.IconOnly
-                color: control.textColor
+                textColor: control.textColor
                 font: control.font
             }
         }
@@ -99,7 +93,7 @@ Button {
                 text:control.text
                 Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
                 visible: display !== Button.IconOnly
-                color: control.textColor
+                textColor: control.textColor
                 font: control.font
             }
         }

--- a/src/Qt5/imports/FluentUI/Controls/FluImage.qml
+++ b/src/Qt5/imports/FluentUI/Controls/FluImage.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.15
+﻿import QtQuick 2.15
 import QtQuick.Controls 2.15
 import FluentUI 1.0
 
@@ -11,6 +11,7 @@ Image {
     property Component errorItem : com_error
     property Component loadingItem: com_loading
     id: control
+    opacity: enabled ? 1 : 0.5
     FluLoader{
         anchors.fill: parent
         sourceComponent: {

--- a/src/Qt5/imports/FluentUI/Controls/FluLoadingButton.qml
+++ b/src/Qt5/imports/FluentUI/Controls/FluLoadingButton.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.15
+﻿import QtQuick 2.15
 import QtQuick.Controls 2.15
 import FluentUI 1.0
 
@@ -13,7 +13,7 @@ FluButton {
             horizontalAlignment: Text.AlignHCenter
             verticalAlignment: Text.AlignVCenter
             font: control.font
-            color: control.textColor
+            textColor: control.textColor
             anchors.verticalCenter: parent.verticalCenter
         }
         Item{

--- a/src/Qt5/imports/FluentUI/Controls/FluText.qml
+++ b/src/Qt5/imports/FluentUI/Controls/FluText.qml
@@ -1,11 +1,11 @@
-import QtQuick 2.15
+﻿import QtQuick 2.15
 import QtQuick.Controls 2.15
 import FluentUI 1.0
 
 Text {
     property color textColor: FluTheme.fontPrimaryColor
     id:text
-    color: textColor
+    color: enabled ? textColor :  Qt.rgba(textColor.r, textColor.g, textColor.b, textColor.a * 0.7)
     renderType: FluTheme.nativeText ? Text.NativeRendering : Text.QtRendering
     font: FluTextStyle.Body
 }


### PR DESCRIPTION
为flutext 和 fluicon增加disable时的alpha值，简化其他控件中对text的disable时颜色的独立控制