### PR TITLE
Fix FluComboBox click issue with AppBar

### DIFF
--- a/src/Qt5/imports/FluentUI/Controls/FluComboBox.qml
+++ b/src/Qt5/imports/FluentUI/Controls/FluComboBox.qml
@@ -107,7 +107,7 @@ T.ComboBox {
         y: control.height
         width: control.width
         height: Math.min(contentItem.implicitHeight, control.Window.height - topMargin - bottomMargin)
-        topMargin: 6
+        topMargin: 32
         bottomMargin: 6
         modal: true
         contentItem: ListView {

--- a/src/Qt6/imports/FluentUI/Controls/FluComboBox.qml
+++ b/src/Qt6/imports/FluentUI/Controls/FluComboBox.qml
@@ -107,7 +107,7 @@ T.ComboBox {
         y: control.height
         width: control.width
         height: Math.min(contentItem.implicitHeight, control.Window.height - topMargin - bottomMargin)
-        topMargin: 6
+        topMargin: 32
         bottomMargin: 6
         modal: true
         contentItem: ListView {


### PR DESCRIPTION
Fixed bug with Popup topMargin because click is consumed by FluAppBar.
If the list of chooses use 100% of the window, the top part of the Popup is not clickable because the FluAppBar consume it for the double click resize of the window. So a simple solution is to set a bigger margin at the top (the size of the AppBar / Tiitle bar) to avoid the issue.