### PR TITLE
Update FluChart.qml

### DIFF
--- a/src/Qt5/imports/FluentUI/Controls/FluChart.qml
+++ b/src/Qt5/imports/FluentUI/Controls/FluChart.qml
@@ -15,7 +15,7 @@ Canvas {
     function animateToNewData()
     {
         chartAnimationProgress = 0.1;
-        d.jsChart.update();
+        d.jsChart?.update();
         chartAnimator.restart();
     }
     QtObject{

--- a/src/Qt6/imports/FluentUI/Controls/FluChart.qml
+++ b/src/Qt6/imports/FluentUI/Controls/FluChart.qml
@@ -14,7 +14,7 @@ Canvas {
     function animateToNewData()
     {
         chartAnimationProgress = 0.1;
-        d.jsChart.update();
+        d.jsChart?.update();
         chartAnimator.restart();
     }
     QtObject{


### PR DESCRIPTION
In some cases, not sure why but animateToNewData is called and jsChart is undefined so it generate an error. Adding a "?" operator avoid the issue if jsChart is not ready, no error and can be called later.