### PR TITLE
Add property autoResetScroll to FluScrollablePage

### DIFF
--- a/src/Qt5/imports/FluentUI/Controls/FluScrollablePage.qml
+++ b/src/Qt5/imports/FluentUI/Controls/FluScrollablePage.qml
@@ -5,8 +5,11 @@ import QtQuick.Controls 2.15
 import FluentUI 1.0
 
 FluPage {
+    property bool autoResetScroll: false
     default property alias content: container.data
+
     Flickable{
+        id: flickable
         clip: true
         anchors.fill: parent
         ScrollBar.vertical: FluScrollBar {}
@@ -15,6 +18,16 @@ FluPage {
         ColumnLayout{
             id:container
             width: parent.width
+        }
+    }
+
+    function resetScroll() {
+        flickable.contentY = 0;
+    }
+
+    StackView.onActivated: {
+        if (autoResetScroll) {
+            resetScroll(); // Call this function to reset the scroll position to the top
         }
     }
 }

--- a/src/Qt6/imports/FluentUI/Controls/FluScrollablePage.qml
+++ b/src/Qt6/imports/FluentUI/Controls/FluScrollablePage.qml
@@ -5,8 +5,11 @@ import QtQuick.Controls
 import FluentUI
 
 FluPage {
+    property bool autoResetScroll: false
     default property alias content: container.data
+
     Flickable{
+        id: flickable
         clip: true
         anchors.fill: parent
         ScrollBar.vertical: FluScrollBar {}
@@ -15,6 +18,16 @@ FluPage {
         ColumnLayout{
             id:container
             width: parent.width
+        }
+    }
+
+    function resetScroll() {
+        flickable.contentY = 0;
+    }
+
+    StackView.onActivated: {
+        if (autoResetScroll) {
+            resetScroll(); // Call this function to reset the scroll position to the top
         }
     }
 }


### PR DESCRIPTION
I use it in my application, I think it can be integrated into the main project. The autoResetScroll property, if true, resets the scroll to the top when StackView.onActivated is called. So the first time a page is viewed but also when the user goes back in the stack.

Not for all applications but in some cases it can be really useful.