### PR TITLE
Fix FluNavigationView noStackPush

### DIFF
--- a/src/Qt5/imports/FluentUI/Controls/FluNavigationView.qml
+++ b/src/Qt5/imports/FluentUI/Controls/FluNavigationView.qml
@@ -1313,7 +1313,7 @@ Item {
             d.stackItems = d.stackItems.concat(nav_list.model[nav_list.currentIndex])
         }
         function noStackPush(){
-            if(loader_content.source.toString() === url){
+            if(loader_content.source.toString() === url && Object.keys(argument).length === 0){
                 return
             }
             loader_content.setSource(url,argument)

--- a/src/Qt6/imports/FluentUI/Controls/FluNavigationView.qml
+++ b/src/Qt6/imports/FluentUI/Controls/FluNavigationView.qml
@@ -1314,7 +1314,7 @@ Item {
             d.stackItems = d.stackItems.concat(nav_list.model[nav_list.currentIndex])
         }
         function noStackPush(){
-            if(loader_content.source.toString() === url){
+            if(loader_content.source.toString() === url && Object.keys(argument).length === 0){
                 return
             }
             loader_content.setSource(url,argument)


### PR DESCRIPTION
Fix FluNavigationView noStackPush to verify if an argument is passed. If true, it is better to set the page has a new one in order to update it with the arguments.

For example, in my app, I have the following pages: 
- List.qml
- Form.qml

The list doesn't have arguments, so a click on the navigation to the list doesn't need to re-render the page. But for the Form.qml, I have an id has parameter. If the id change, it is not the same data in the form, so I need to re-render like a new one. In my use case, the search box list all the clients and I can switch between them from this input, without the PR, it doesn't work because the code consider it is the same page even if the arguments are different.