### PR TITLE
fix: 修复了在 Ubuntu 中启用亚克力效果无效且导致程序崩溃的问题

### DIFF
--- a/src/FluTools.cpp
+++ b/src/FluTools.cpp
@@ -282,7 +282,22 @@ QString FluTools::getWallpaperFilePath() {
             auto path = result.mid(startIndex + 7, result.length() - startIndex - 8);
             return path;
         }
+    } else if (type == "ubuntu") {
+        QProcess process;
+        QStringList args;
+        args << "get";
+        args << "org.gnome.desktop.background";
+        args << "picture-uri";
+        process.start("gsettings", args);
+        process.waitForFinished();
+        QByteArray result = process.readAllStandardOutput().trimmed();
+        result = result.mid(1, result.length() - 2);
+        if (result.startsWith("file:///")) {
+            auto path = result.mid(7);
+            return path;
+        }
     }
+    return {};
 #elif defined(Q_OS_MACOS)
     QProcess process;
     QStringList args;


### PR DESCRIPTION
1. 在 Ubuntu 中设置 `FluTheme.blurBehindWindowEnabled=true` 时报错 Segmentation Fault，此错误应该在非 UOS 的 Linux 下会出现，修复此问题
![1735224018509](https://github.com/user-attachments/assets/af74c88c-e2ba-41b4-967e-3fce42a89e29)

2. 让 Ubuntu gnome 桌面亚克力背景生效
![1735224971338](https://github.com/user-attachments/assets/92309438-e1d3-4717-a9d3-b64eca607b9c)
