### PR TITLE
fix(ci): 修复 GitHub Action 打包的 AppImage 语言切换无效

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -69,6 +69,11 @@ jobs:
       - name: Check if svg file exists
         run: if [ ! -f "${targetName}.svg" ]; then echo "File not found, creating..."; touch ${targetName}.svg; fi
 
+      - name: Copy translation files
+        run: |
+          mkdir -p bin/release/usr/bin/
+          cp -r bin/Release/i18n/ bin/release/usr/bin/i18n/
+
       - name: package
         run: |
           # make sure Qt plugin finds QML sources so it can deploy the imported files


### PR DESCRIPTION
GitHub Action 打包的 example_x.x.x_ubuntu-latest_Qt6.6.2.AppImage 缺少语言包，切换中文重启后还是显示英文。

修复前：
![image](https://github.com/user-attachments/assets/a77e51b5-7086-4ddc-988c-9970c3a144e9)

修复后：
![image](https://github.com/user-attachments/assets/d2d290c3-3947-443d-8335-f25f3dce9bd7)
