### PR TITLE
修复 FluColorPicker 存在的颜色同步与输入问题

### DIFF
--- a/src/Qt5/imports/FluentUI/Controls/FluColorPicker.qml
+++ b/src/Qt5/imports/FluentUI/Controls/FluColorPicker.qml
@@ -47,6 +47,17 @@ Button{
         implicitWidth: 326
         implicitHeight: 560
         closePolicy: Popup.CloseOnEscape
+        onClosed: {
+            text_box_r.focus = false;
+            text_box_g.focus = false;
+            text_box_b.focus = false;
+            text_box_a.focus = false;
+            text_box_color.focus = false;
+        }
+        onOpened: {
+            layout_color_hue.updateColorText(current);
+            text_box_color.textEdited();
+        }
         Rectangle{
             id:layout_actions
             width: parent.width
@@ -148,7 +159,9 @@ Button{
                             if(color.a===1){
                                 colorString = "FF"+colorString
                             }
-                            text_box_color.text = colorString.toUpperCase()
+                            if (!text_box_color.activeFocus) {
+                                text_box_color.text = colorString.toUpperCase();
+                            }
                         }
                         property color blackColor: {
                             var c = whiteColor
@@ -279,6 +292,11 @@ Button{
                         preventStealing: true
                         function handleMouse(mouse) {
                             if (mouse.buttons & Qt.LeftButton) {
+                                text_box_r.focus = false;
+                                text_box_g.focus = false;
+                                text_box_b.focus = false;
+                                text_box_a.focus = false;
+                                text_box_color.focus = false;
                                 pickerCursor.x = Math.max(0,Math.min(mouse.x - colorHandleRadius,width-2*colorHandleRadius));
                                 pickerCursor.y = Math.max(0,Math.min(mouse.y - colorHandleRadius,height-2*colorHandleRadius));
                             }
@@ -369,6 +387,11 @@ Button{
                             preventStealing: true
                             function handleMouse(mouse) {
                                 if (mouse.buttons & Qt.LeftButton) {
+                                    text_box_r.focus = false;
+                                    text_box_g.focus = false;
+                                    text_box_b.focus = false;
+                                    text_box_a.focus = false;
+                                    text_box_color.focus = false;
                                     blackCursor.x = Math.max(0,Math.min(mouse.x - 6,width-2*6));
                                     blackCursor.y = 0
                                 }
@@ -438,6 +461,11 @@ Button{
                             preventStealing: true
                             function handleMouse(mouse) {
                                 if (mouse.buttons & Qt.LeftButton) {
+                                    text_box_r.focus = false;
+                                    text_box_g.focus = false;
+                                    text_box_b.focus = false;
+                                    text_box_a.focus = false;
+                                    text_box_color.focus = false;
                                     opacityCursor.x = Math.max(0,Math.min(mouse.x - 6,width-2*6));
                                     opacityCursor.y = 0
                                 }
@@ -472,7 +500,7 @@ Button{
                             id:text_box_color
                             width: 136
                             validator: RegularExpressionValidator {
-                                regularExpression: /^[0-9A-F]{8}$/
+                                regularExpression: /^[0-9A-Fa-f]{8}$/
                             }
                             anchors{
                                 right: parent.right
@@ -495,6 +523,11 @@ Button{
                                                 parseInt(colorString.substring(6, 8), 16) / 255,
                                                 parseInt(colorString.substring(0, 2), 16) / 255)
                                     layout_color_hue.colorValue = c
+                                    layout_color_hue.updateColorText(c);
+                                    text_box_r.textEdited();
+                                    text_box_g.textEdited();
+                                    text_box_b.textEdited();
+                                    text_box_a.textEdited();
                                 }
                             }
                         }

--- a/src/Qt6/imports/FluentUI/Controls/FluColorPicker.qml
+++ b/src/Qt6/imports/FluentUI/Controls/FluColorPicker.qml
@@ -48,6 +48,17 @@ Button{
         implicitWidth: 326
         implicitHeight: 560
         closePolicy: Popup.CloseOnEscape
+        onClosed: {
+            text_box_r.focus = false;
+            text_box_g.focus = false;
+            text_box_b.focus = false;
+            text_box_a.focus = false;
+            text_box_color.focus = false;
+        }
+        onOpened: {
+            layout_color_hue.updateColorText(current);
+            text_box_color.textEdited();
+        }
         Rectangle{
             id:layout_actions
             width: parent.width
@@ -149,7 +160,9 @@ Button{
                             if(color.a===1){
                                 colorString = "FF"+colorString
                             }
-                            text_box_color.text = colorString.toUpperCase()
+                            if (!text_box_color.activeFocus) {
+                                text_box_color.text = colorString.toUpperCase();
+                            }
                         }
                         property color blackColor: {
                             var c = whiteColor
@@ -280,6 +293,11 @@ Button{
                         preventStealing: true
                         function handleMouse(mouse) {
                             if (mouse.buttons & Qt.LeftButton) {
+                                text_box_r.focus = false;
+                                text_box_g.focus = false;
+                                text_box_b.focus = false;
+                                text_box_a.focus = false;
+                                text_box_color.focus = false;
                                 pickerCursor.x = Math.max(0,Math.min(mouse.x - colorHandleRadius,width-2*colorHandleRadius));
                                 pickerCursor.y = Math.max(0,Math.min(mouse.y - colorHandleRadius,height-2*colorHandleRadius));
                             }
@@ -370,6 +388,11 @@ Button{
                             preventStealing: true
                             function handleMouse(mouse) {
                                 if (mouse.buttons & Qt.LeftButton) {
+                                    text_box_r.focus = false;
+                                    text_box_g.focus = false;
+                                    text_box_b.focus = false;
+                                    text_box_a.focus = false;
+                                    text_box_color.focus = false;
                                     blackCursor.x = Math.max(0,Math.min(mouse.x - 6,width-2*6));
                                     blackCursor.y = 0
                                 }
@@ -439,6 +462,11 @@ Button{
                             preventStealing: true
                             function handleMouse(mouse) {
                                 if (mouse.buttons & Qt.LeftButton) {
+                                    text_box_r.focus = false;
+                                    text_box_g.focus = false;
+                                    text_box_b.focus = false;
+                                    text_box_a.focus = false;
+                                    text_box_color.focus = false;
                                     opacityCursor.x = Math.max(0,Math.min(mouse.x - 6,width-2*6));
                                     opacityCursor.y = 0
                                 }
@@ -473,7 +501,7 @@ Button{
                             id:text_box_color
                             width: 136
                             validator: RegularExpressionValidator {
-                                regularExpression: /^[0-9A-F]{8}$/
+                                regularExpression: /^[0-9A-Fa-f]{8}$/
                             }
                             anchors{
                                 right: parent.right
@@ -496,6 +524,11 @@ Button{
                                                 parseInt(colorString.substring(6, 8), 16) / 255,
                                                 parseInt(colorString.substring(0, 2), 16) / 255)
                                     layout_color_hue.colorValue = c
+                                    layout_color_hue.updateColorText(c);
+                                    text_box_r.textEdited();
+                                    text_box_g.textEdited();
+                                    text_box_b.textEdited();
+                                    text_box_a.textEdited();
                                 }
                             }
                         }


### PR DESCRIPTION
- 修复了 FluColorPicker 打开时滑块与 RGBA/HEX 数值未正确匹配当前颜色的问题

  前：
  
  https://github.com/user-attachments/assets/99d86f34-bbd2-4299-8a7a-a0e6c68cbfcd
  
  后：
  
  https://github.com/user-attachments/assets/38a995c2-9302-4b7a-b7b3-82890b54d8d9

- 修复了 FluColorPicker 设置 HEX 值时，RGBA 数值未同步更新的问题
- 修复了 FluColorPicker HEX 输入框只能接受大写 A-F 字符的问题

  前：

  https://github.com/user-attachments/assets/c05a5b0b-56e8-4abc-8c5d-86ba692e22ff

  后：

  https://github.com/user-attachments/assets/7159456c-ee64-4c3b-856d-9697e926c816


