### PR TITLE
修复FluPivot 切换选中项目时标题下划线动画未能完全关闭的问题

### DIFF
--- a/src/Qt5/imports/FluentUI/Controls/FluPivot.qml
+++ b/src/Qt5/imports/FluentUI/Controls/FluPivot.qml
@@ -31,21 +31,15 @@ Page {
         interactive: false
         orientation: ListView.Horizontal
         highlightMoveDuration: FluTheme.animationEnabled ? 167 : 0
+        highlightResizeDuration: FluTheme.animationEnabled ? 167 : 0
         highlight: Item{
             clip: true
             Rectangle{
                 height: 3
                 radius: 1.5
                 color: FluTheme.primaryColor
-                width: nav_list.currentItem ? nav_list.currentItem.width : 0
+                width: nav_list.currentItem.width
                 y:d.tabY
-                Behavior on width {
-                    enabled: FluTheme.animationEnabled
-                    NumberAnimation{
-                        duration: 167
-                        easing.type: Easing.OutCubic
-                    }
-                }
             }
         }
         delegate: Button{

--- a/src/Qt6/imports/FluentUI/Controls/FluPivot.qml
+++ b/src/Qt6/imports/FluentUI/Controls/FluPivot.qml
@@ -32,21 +32,15 @@ Page {
         interactive: false
         orientation: ListView.Horizontal
         highlightMoveDuration: FluTheme.animationEnabled ? 167 : 0
+        highlightResizeDuration: FluTheme.animationEnabled ? 167 : 0
         highlight: Item{
             clip: true
             Rectangle{
                 height: 3
                 radius: 1.5
                 color: FluTheme.primaryColor
-                width: nav_list.currentItem ? nav_list.currentItem.width : 0
+                width: nav_list.currentItem.width
                 y:d.tabY
-                Behavior on width {
-                    enabled: FluTheme.animationEnabled
-                    NumberAnimation{
-                        duration: 167
-                        easing.type: Easing.OutCubic
-                    }
-                }
             }
         }
         delegate: Button{


### PR DESCRIPTION
修复了在 `FluTheme.animationEnabled = false` 时，从文字较少的 title 切换到文字较多的 title 时，下划线仍然存在尺寸变化动画的问题。

前：

https://github.com/user-attachments/assets/a59e9d0b-87d4-421c-87d9-8f3f7355aab5

后：

https://github.com/user-attachments/assets/3455a8e2-620a-4d46-9953-ece649427609

