### PR TITLE
修复 Singleton 类重定义的问题

### DIFF
--- a/example/src/AppInfo.h
+++ b/example/src/AppInfo.h
@@ -13,6 +13,6 @@ class AppInfo : public QObject {
   explicit AppInfo(QObject *parent = nullptr);
 
  public:
-  SINGLETON(AppInfo)
+  EXAMPLESINGLETON(AppInfo)
   [[maybe_unused]] Q_INVOKABLE void testCrash();
 };

--- a/example/src/helper/InitializrHelper.h
+++ b/example/src/helper/InitializrHelper.h
@@ -15,7 +15,7 @@ private:
     void templateToFile(const QString &source, const QString &dest, Args &&...args);
 
 public:
-    SINGLETON(InitializrHelper)
+    EXAMPLESINGLETON(InitializrHelper)
     ~InitializrHelper() override;
     [[maybe_unused]] Q_INVOKABLE void generate(const QString &name, const QString &path);
     Q_SIGNAL void error(const QString &message);

--- a/example/src/helper/Network.h
+++ b/example/src/helper/Network.h
@@ -144,7 +144,7 @@ private:
     explicit Network(QObject *parent = nullptr);
 
 public:
-    SINGLETON(Network)
+    EXAMPLESINGLETON(Network)
 
     static Network *create(QQmlEngine *qmlEngine, QJSEngine *jsEngine) {
         return getInstance();

--- a/example/src/helper/SettingsHelper.h
+++ b/example/src/helper/SettingsHelper.h
@@ -15,7 +15,7 @@ private:
     explicit SettingsHelper(QObject *parent = nullptr);
 
 public:
-    SINGLETON(SettingsHelper)
+    EXAMPLESINGLETON(SettingsHelper)
     ~SettingsHelper() override;
     void init(char *argv[]);
     Q_INVOKABLE void saveDarkMode(int darkModel) {

--- a/example/src/helper/TranslateHelper.h
+++ b/example/src/helper/TranslateHelper.h
@@ -14,7 +14,7 @@ private:
     [[maybe_unused]] explicit TranslateHelper(QObject *parent = nullptr);
 
 public:
-    SINGLETON(TranslateHelper)
+    EXAMPLESINGLETON(TranslateHelper)
     ~TranslateHelper() override;
     void init(QQmlEngine *engine);
 

--- a/example/src/singleton.h
+++ b/example/src/singleton.h
@@ -4,22 +4,22 @@
  * @brief The Singleton class
  */
 template <typename T>
-class Singleton {
+class ExampleSingleton {
 public:
     static T *getInstance();
 };
 
 template <typename T>
-T *Singleton<T>::getInstance() {
+T *ExampleSingleton<T>::getInstance() {
     static T *instance = new T();
     return instance;
 }
 
-#define SINGLETON(Class)                                                                           \
+#define EXAMPLESINGLETON(Class)                                                                           \
 private:                                                                                           \
-    friend class Singleton<Class>;                                                                 \
+    friend class ExampleSingleton<Class>;                                                                 \
                                                                                                    \
 public:                                                                                            \
     static Class *getInstance() {                                                                  \
-        return Singleton<Class>::getInstance();                                                    \
+        return ExampleSingleton<Class>::getInstance();                                                    \
     }


### PR DESCRIPTION
example/src/singleton.h 与 src/singleton.h 两文件中，Singleton 重定义

编译选项：
FLUENTUI_BUILD_STATIC_LIB=ON

问题：
fix #564