### PR TITLE
修复FluCarousel手动翻页的问题

### DIFF
--- a/src/Qt5/imports/FluentUI/Controls/FluCarousel.qml
+++ b/src/Qt5/imports/FluentUI/Controls/FluCarousel.qml
@@ -24,7 +24,7 @@ Item {
     }
     QtObject{
         id:d
-        property bool flagXChanged: true
+        property bool flagXChanged: false
         property bool isAnimEnable: control.autoPlay && list_view.count>3
         function setData(data){
             if(!data){
@@ -88,14 +88,17 @@ Item {
             }
         }
         onMovementEnded:{
+            d.flagXChanged = false
+            list_view.highlightMoveDuration = 0
             currentIndex = list_view.contentX/list_view.width
             if(currentIndex === 0){
                 currentIndex = list_view.count-2
             }else if(currentIndex === list_view.count-1){
                 currentIndex = 1
             }
-            d.flagXChanged = false
-            timer_run.restart()
+            if(d.isAnimEnable){
+                timer_run.restart()
+            }
         }
         onMovementStarted: {
             d.flagXChanged = true
@@ -104,12 +107,12 @@ Item {
         onContentXChanged: {
             if(d.flagXChanged){
                 var maxX = Math.min(list_view.width*(currentIndex+1),list_view.count*list_view.width)
-                var minY = Math.max(0,(list_view.width*(currentIndex-1)))
+                var minX = Math.max(0,(list_view.width*(currentIndex-1)))
                 if(contentX>=maxX){
                     contentX = maxX
                 }
-                if(contentX<=minY){
-                    contentX = minY
+                if(contentX<=minX){
+                    contentX = minX
                 }
             }
         }

--- a/src/Qt5/imports/FluentUI/Controls/FluProgressBar.qml
+++ b/src/Qt5/imports/FluentUI/Controls/FluProgressBar.qml
@@ -14,13 +14,6 @@ ProgressBar{
         id:d
         property real _radius: strokeWidth/2
     }
-    onIndeterminateChanged:{
-        if(!indeterminate){
-            animator_x.duration = 0
-            rect_progress.x = 0
-            animator_x.duration = control.duration
-        }
-    }
     background: Rectangle {
         implicitWidth: 150
         implicitHeight: control.strokeWidth
@@ -45,6 +38,11 @@ ProgressBar{
                 id: animator_x
                 running: control.indeterminate && control.visible
                 loops: Animation.Infinite
+                onRunningChanged: {
+                    if(!running){
+                        rect_progress.x = 0
+                    }
+                }
                 PropertyAnimation {
                     from: -rect_progress.width
                     to: control.width + rect_progress.width

--- a/src/Qt6/imports/FluentUI/Controls/FluCarousel.qml
+++ b/src/Qt6/imports/FluentUI/Controls/FluCarousel.qml
@@ -24,7 +24,7 @@ Item {
     }
     QtObject{
         id:d
-        property bool flagXChanged: true
+        property bool flagXChanged: false
         property bool isAnimEnable: control.autoPlay && list_view.count>3
         function setData(data){
             if(!data){
@@ -88,14 +88,17 @@ Item {
             }
         }
         onMovementEnded:{
+            d.flagXChanged = false
+            list_view.highlightMoveDuration = 0
             currentIndex = list_view.contentX/list_view.width
             if(currentIndex === 0){
                 currentIndex = list_view.count-2
             }else if(currentIndex === list_view.count-1){
                 currentIndex = 1
             }
-            d.flagXChanged = false
-            timer_run.restart()
+            if(d.isAnimEnable){
+                timer_run.restart()
+            }
         }
         onMovementStarted: {
             d.flagXChanged = true
@@ -104,12 +107,12 @@ Item {
         onContentXChanged: {
             if(d.flagXChanged){
                 var maxX = Math.min(list_view.width*(currentIndex+1),list_view.count*list_view.width)
-                var minY = Math.max(0,(list_view.width*(currentIndex-1)))
+                var minX = Math.max(0,(list_view.width*(currentIndex-1)))
                 if(contentX>=maxX){
                     contentX = maxX
                 }
-                if(contentX<=minY){
-                    contentX = minY
+                if(contentX<=minX){
+                    contentX = minX
                 }
             }
         }

--- a/src/Qt6/imports/FluentUI/Controls/FluProgressBar.qml
+++ b/src/Qt6/imports/FluentUI/Controls/FluProgressBar.qml
@@ -15,13 +15,6 @@ ProgressBar{
         id:d
         property real _radius: strokeWidth/2
     }
-    onIndeterminateChanged:{
-        if(!indeterminate){
-            animator_x.duration = 0
-            rect_progress.x = 0
-            animator_x.duration = control.duration
-        }
-    }
     background: Rectangle {
         implicitWidth: 150
         implicitHeight: control.strokeWidth
@@ -46,6 +39,11 @@ ProgressBar{
                 id: animator_x
                 running: control.indeterminate && control.visible
                 loops: Animation.Infinite
+                onRunningChanged: {
+                    if(!running){
+                        rect_progress.x = 0
+                    }
+                }
                 PropertyAnimation {
                     from: -rect_progress.width
                     to: control.width + rect_progress.width


### PR DESCRIPTION
1. 修复 #563，禁止自动轮播后，手动翻页会触发自动轮播的问题
修复前：

https://github.com/user-attachments/assets/06266650-f937-4e10-b460-30a394f53c44


2. 修复第1个问题后，发现手动翻页不能无限轮播，进一步做修复
修复前：

https://github.com/user-attachments/assets/5d17a975-cdfa-4210-a83e-222a3f932740


完整修复后：

https://github.com/user-attachments/assets/466c6484-e8e3-45d2-b12f-50f9999e471b

fixed #563 