### PR TITLE
修复Pivot的示例代码错误

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,20 @@
+{
+    "MicroPython.executeButton": [
+        {
+            "text": "▶",
+            "tooltip": "运行",
+            "alignment": "left",
+            "command": "extension.executeFile",
+            "priority": 3.5
+        }
+    ],
+    "MicroPython.syncButton": [
+        {
+            "text": "$(sync)",
+            "tooltip": "同步",
+            "alignment": "left",
+            "command": "extension.execute",
+            "priority": 4
+        }
+    ]
+}

--- a/example/qml/page/T_Pivot.qml
+++ b/example/qml/page/T_Pivot.qml
@@ -49,26 +49,26 @@ FluScrollablePage{
         Layout.topMargin: -6
         code:'FluPivot{
     anchors.fill: parent
-    FluPivotItem:{
-        text: qsTr("All")
+    FluPivotItem {
+        title: qsTr("All")
         contentItem: FluText{
             text: qsTr("All emails go here.")
         }
     }
-    FluPivotItem:{
-        text: qsTr("Unread")
+    FluPivotItem {
+        title: qsTr("Unread")
         contentItem: FluText{
             text: qsTr("Unread emails go here.")
         }
     }
-    FluPivotItem:{
-        text: qsTr("Flagged")
+    FluPivotItem {
+        title: qsTr("Flagged")
         contentItem: FluText{
             text: qsTr("Flagged emails go here.")
         }
     }
-    FluPivotItem:{
-        text: qsTr("Urgent")
+    FluPivotItem {
+        title: qsTr("Urgent")
         contentItem: FluText{
             text: qsTr("Urgent emails go here.")
         }


### PR DESCRIPTION
修复Pivot的示例代码错误，具体为删除FluPivotItem后面的冒号，将FluPivotItem的text属性改为title属性