### PR TITLE
fix: 优化示例中加载按钮交互效果

### DIFF
--- a/example/example_en_US.ts
+++ b/example/example_en_US.ts
@@ -969,8 +969,14 @@ Updated content:
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/page/T_Buttons.qml" line="222"/>
         <location filename="qml/page/T_Buttons.qml" line="238"/>
         <source>Loading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/page/T_Buttons.qml" line="238"/>
+        <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2291,39 +2297,39 @@ Some contents...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qml/page/T_TabView.qml" line="45"/>
-        <location filename="qml/page/T_TabView.qml" line="47"/>
+        <location filename="qml/page/T_TabView.qml" line="44"/>
+        <location filename="qml/page/T_TabView.qml" line="46"/>
         <source>Equal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qml/page/T_TabView.qml" line="54"/>
+        <location filename="qml/page/T_TabView.qml" line="53"/>
         <source>SizeToContent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qml/page/T_TabView.qml" line="61"/>
+        <location filename="qml/page/T_TabView.qml" line="60"/>
         <source>Compact</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qml/page/T_TabView.qml" line="69"/>
+        <location filename="qml/page/T_TabView.qml" line="68"/>
         <source>Tab Close Button Visibility:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qml/page/T_TabView.qml" line="74"/>
-        <location filename="qml/page/T_TabView.qml" line="84"/>
+        <location filename="qml/page/T_TabView.qml" line="72"/>
+        <location filename="qml/page/T_TabView.qml" line="82"/>
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qml/page/T_TabView.qml" line="77"/>
+        <location filename="qml/page/T_TabView.qml" line="75"/>
         <source>Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qml/page/T_TabView.qml" line="91"/>
+        <location filename="qml/page/T_TabView.qml" line="89"/>
         <source>OnHover</source>
         <translation type="unfinished"></translation>
     </message>

--- a/example/example_zh_CN.ts
+++ b/example/example_zh_CN.ts
@@ -995,9 +995,15 @@ Updated content:
         <translation type="unfinished">加载按钮</translation>
     </message>
     <message>
+        <location filename="qml/page/T_Buttons.qml" line="222"/>
         <location filename="qml/page/T_Buttons.qml" line="238"/>
         <source>Loading</source>
         <translation type="unfinished">正在加载</translation>
+    </message>
+    <message>
+        <location filename="qml/page/T_Buttons.qml" line="238"/>
+        <source>Normal</source>
+        <translation type="unfinished">开启加载</translation>
     </message>
     <message>
         <location filename="qml/page/T_Buttons.qml" line="270"/>
@@ -2480,39 +2486,39 @@ Some contents...</source>
         <translation type="unfinished">选项卡宽度：</translation>
     </message>
     <message>
-        <location filename="qml/page/T_TabView.qml" line="45"/>
-        <location filename="qml/page/T_TabView.qml" line="47"/>
+        <location filename="qml/page/T_TabView.qml" line="44"/>
+        <location filename="qml/page/T_TabView.qml" line="46"/>
         <source>Equal</source>
         <translation type="unfinished">相同宽度</translation>
     </message>
     <message>
-        <location filename="qml/page/T_TabView.qml" line="54"/>
+        <location filename="qml/page/T_TabView.qml" line="53"/>
         <source>SizeToContent</source>
         <translation type="unfinished">由内容</translation>
     </message>
     <message>
-        <location filename="qml/page/T_TabView.qml" line="61"/>
+        <location filename="qml/page/T_TabView.qml" line="60"/>
         <source>Compact</source>
         <translation type="unfinished">紧凑</translation>
     </message>
     <message>
-        <location filename="qml/page/T_TabView.qml" line="69"/>
+        <location filename="qml/page/T_TabView.qml" line="68"/>
         <source>Tab Close Button Visibility:</source>
         <translation type="unfinished">选项卡关闭按钮可见性：</translation>
     </message>
     <message>
-        <location filename="qml/page/T_TabView.qml" line="74"/>
-        <location filename="qml/page/T_TabView.qml" line="84"/>
+        <location filename="qml/page/T_TabView.qml" line="72"/>
+        <location filename="qml/page/T_TabView.qml" line="82"/>
         <source>Always</source>
         <translation type="unfinished">可见</translation>
     </message>
     <message>
-        <location filename="qml/page/T_TabView.qml" line="77"/>
+        <location filename="qml/page/T_TabView.qml" line="75"/>
         <source>Never</source>
         <translation type="unfinished">不可见</translation>
     </message>
     <message>
-        <location filename="qml/page/T_TabView.qml" line="91"/>
+        <location filename="qml/page/T_TabView.qml" line="89"/>
         <source>OnHover</source>
         <translation type="unfinished">鼠标悬浮显示</translation>
     </message>

--- a/example/qml/page/T_Buttons.qml
+++ b/example/qml/page/T_Buttons.qml
@@ -219,7 +219,7 @@ FluScrollablePage{
         FluLoadingButton{
             id: btn_loading
             loading: loading_button_switch.checked
-            text: qsTr("Loading Button")
+            text: loading_button_switch.checked ? qsTr("Loading") : qsTr("Loading Button")
             anchors{
                 verticalCenter: parent.verticalCenter
                 left: parent.left
@@ -235,7 +235,7 @@ FluScrollablePage{
                 right: parent.right
                 verticalCenter: parent.verticalCenter
             }
-            text: qsTr("Loading")
+            text: loading_button_switch.checked ? qsTr("Loading") : qsTr("Normal")
         }
     }
     CodeExpander{


### PR DESCRIPTION
优化 example 中加载按钮页面交互效果

修改前：
![image](https://github.com/user-attachments/assets/ee82eebc-ba80-4cb4-aebd-f963b9ad2a7e)
![image](https://github.com/user-attachments/assets/74dfdbcf-cf0f-4d35-a7d9-9f148bb33985)

**修改后**
![image](https://github.com/user-attachments/assets/33bde845-d746-4357-9959-bcb954281bf1)
![image](https://github.com/user-attachments/assets/cf23bf41-1299-48e1-b3b6-c21c008901d1)

**英文部分**
![image](https://github.com/user-attachments/assets/56f24716-0d13-466c-8561-92611e7761af)
![image](https://github.com/user-attachments/assets/3246a35f-0c7d-45d7-86ec-514f36bfd20a)

