### PR TITLE
修复FluTreeModel::setDataSource内存泄漏问题

### DIFF
--- a/src/FluTreeModel.cpp
+++ b/src/FluTreeModel.cpp
@@ -107,7 +107,7 @@ void FluTreeModel::checkRow(int row, bool checked) {
 void FluTreeModel::setDataSource(QList<QMap<QString, QVariant>> data) {
     _dataSource.clear();
     if (_root) {
-        delete _root;
+        _root->deleteLater();
         _root = nullptr;
     }
     _root = new FluTreeNode(this);
@@ -115,7 +115,7 @@ void FluTreeModel::setDataSource(QList<QMap<QString, QVariant>> data) {
     while (data.count() > 0) {
         auto item = data.at(data.count() - 1);
         data.pop_back();
-        auto *node = new FluTreeNode(this);
+        auto *node = new FluTreeNode(_root);
         node->_depth = item.value("__depth").toInt();
         node->_parent = item.value("__parent").value<FluTreeNode *>();
         node->_data = item;

--- a/src/Qt5/imports/FluentUI/Controls/FluTreeView.qml
+++ b/src/Qt5/imports/FluentUI/Controls/FluTreeView.qml
@@ -474,6 +474,7 @@ Rectangle {
                     }
                     return {}
                 }
+                active: rowModel !== undefined && rowModel !== null
                 sourceComponent: {
                     if(column === 0)
                         return com_column

--- a/src/Qt6/imports/FluentUI/Controls/FluTreeView.qml
+++ b/src/Qt6/imports/FluentUI/Controls/FluTreeView.qml
@@ -474,6 +474,7 @@ Rectangle {
                     }
                     return {}
                 }
+                active: rowModel !== undefined && rowModel !== null
                 sourceComponent: {
                     if(column === 0)
                         return com_column


### PR DESCRIPTION
多次调用setDataSource会存在内存泄漏，直到FluTreeModel销毁，因为子节点的父对象是FluTreeModel而不是_root，而_dataSource.clear()并不会销毁子节点对象，需要qDeleteAll(_dataSource)，或将子节点父对象设为_root

修复前：

https://github.com/user-attachments/assets/d42c44eb-0d00-4d90-a7f4-1679c62e2f8e


修复后：

https://github.com/user-attachments/assets/46d7eef4-84c6-487e-aa35-3bf1d30b0097

