### PR TITLE
fix: ComboBox list text display error

### DIFF
--- a/src/Qt6/imports/FluentUI/Controls/FluComboBox.qml
+++ b/src/Qt6/imports/FluentUI/Controls/FluComboBox.qml
@@ -23,7 +23,15 @@ T.ComboBox {
     enabled: !disabled
     delegate: FluItemDelegate {
         width: ListView.view.width
-        text: control.textRole ? (Array.isArray(control.model) ? modelData[control.textRole] : model[control.textRole]) : modelData
+        text: {
+            if (!control.textRole)
+                return modelData
+
+            if (modelData && typeof modelData === "object")
+                return modelData[control.textRole]
+
+            return model[control.textRole]
+        }
         palette.text: control.palette.text
         font: control.font
         palette.highlightedText: control.palette.highlightedText


### PR DESCRIPTION
## 当FluComboBox的model为js数组时，下拉列表中的文字无法显示
<img width="131" height="247" alt="image" src="https://github.com/user-attachments/assets/e4fb0913-1e8a-46a5-8104-20bbafe63a3a" />

原因：Array.isArray(control.model)不可靠